### PR TITLE
ci: add GitHub Actions workflow and fix luna AttrValue API

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [native, js]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install MoonBit CLI
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+      - name: Moon update
+        run: moon update
+      - name: Moon check
+        run: moon check --deny-warn --target ${{ matrix.target }} 2> >(grep -v 'WARN Duplicate alias' >&2)
+      - name: Moon test
+        if: matrix.target == 'native'
+        run: moon test --target native

--- a/src/runtime/server/server.mbt
+++ b/src/runtime/server/server.mbt
@@ -15,9 +15,9 @@ pub fn component_ssr_meta(
   name : String,
   props_json : String,
   children : Array[@luna_core.StaticDomNode],
-  meta_attrs : Array[(String, @luna_core.AttrValue)],
+  meta_attrs : Array[(String, @luna_core.Attr[Unit, String])],
 ) -> @luna_core.StaticDomNode {
-  let attrs : Array[(String, @luna_core.AttrValue)] = [
+  let attrs : Array[(String, @luna_core.Attr[Unit, String])] = [
     ("data-vm-component", @luna_core.attr_static(name)),
     ("data-vm-props", @luna_core.attr_static(props_json)),
   ]
@@ -43,7 +43,7 @@ pub fn island_ssr_meta(
   props_json : String,
   children : Array[@luna_core.StaticDomNode],
   mode : @vm.HydrationMode,
-  meta_attrs : Array[(String, @luna_core.AttrValue)],
+  meta_attrs : Array[(String, @luna_core.Attr[Unit, String])],
 ) -> @luna_core.StaticDomNode {
   match mode {
     Only => island_only_ssr(name, props_json, meta_attrs)
@@ -63,9 +63,9 @@ pub fn island_ssr_meta(
 fn island_only_ssr(
   name : String,
   props_json : String,
-  meta_attrs : Array[(String, @luna_core.AttrValue)],
+  meta_attrs : Array[(String, @luna_core.Attr[Unit, String])],
 ) -> @luna_core.StaticDomNode {
-  let attrs : Array[(String, @luna_core.AttrValue)] = [
+  let attrs : Array[(String, @luna_core.Attr[Unit, String])] = [
     ("data-vm-island", @luna_core.attr_static(name)),
     ("data-vm-client", @luna_core.attr_static("only")),
     ("data-vm-props", @luna_core.attr_static(props_json)),
@@ -81,9 +81,9 @@ fn island_defer_ssr(
   name : String,
   props_json : String,
   children : Array[@luna_core.StaticDomNode],
-  meta_attrs : Array[(String, @luna_core.AttrValue)],
+  meta_attrs : Array[(String, @luna_core.Attr[Unit, String])],
 ) -> @luna_core.StaticDomNode {
-  let attrs : Array[(String, @luna_core.AttrValue)] = [
+  let attrs : Array[(String, @luna_core.Attr[Unit, String])] = [
     ("data-vm-component", @luna_core.attr_static(name)),
     ("data-vm-props", @luna_core.attr_static(props_json)),
   ]


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow with native/js target matrix
- Fix `luna_core.AttrValue` → `Attr[Unit, String]` to match luna API update

### CI configuration

- `moon check --deny-warn` for both native and js targets
- `moon test` for native target
- yacc duplicate-alias warning filtered from stderr

## Test plan

- [x] `moon check --deny-warn --target native` passes
- [x] `moon check --deny-warn --target js` passes
- [x] All 175 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)