### PR TITLE
Add component v-model and radio input v-model support, tests, and ISSUES backlog

### DIFF
--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -1,0 +1,78 @@
+# Implementation Backlog (Issue Drafts)
+
+このファイルは、現状のコードベース/README/テストを確認して抽出した「未実装・未対応項目」の Issue 草案です。
+
+## Issue 1: component-side `v-model` を実装する
+- **Status**: Open
+- **Priority**: High
+- **根拠**:
+  - README の supported directives に `component-side v-model` が記載されている
+  - しかし compiler 側で `component v-model is not supported yet` を返している
+- **対象ファイル（想定）**:
+  - `src/compiler/template/builder_validate.mbt`
+  - `src/compiler/codegen/attrs_component.mbt`
+  - `src/compiler/snapshot/attrs_test.mbt`
+- **受け入れ条件**:
+  1. `<MyInput v-model='state.get()' />` がコンパイル可能
+  2. `v-model:prop` / `v-model` の component binding ルールを明文化
+  3. snapshot test を追加
+
+## Issue 2: `v-model` on `<input type="radio">` を実装する
+- **Status**: Open
+- **Priority**: Medium
+- **根拠**:
+  - compiler validate で `v-model on <input type="radio"> is not supported yet`
+- **対象ファイル（想定）**:
+  - `src/compiler/template/builder_validate.mbt`
+  - `src/compiler/codegen/attrs_binding.mbt`
+  - `src/compiler/snapshot/attrs_test.mbt`
+- **受け入れ条件**:
+  1. `checked` と value 同期のコード生成
+  2. change イベントで target 更新
+  3. snapshot test を追加
+
+## Issue 3: `v-model` on `<input type="file">` 対応方針を決める
+- **Status**: Open
+- **Priority**: Medium
+- **根拠**:
+  - compiler validate で `v-model on <input type="file"> is not supported yet`
+- **対応案**:
+  - 仕様上無効（明示エラー維持）にするか、`files` 同期を設計して実装するかを決定
+- **受け入れ条件**:
+  1. README と compiler error message の整合
+  2. 選択した方針の test を追加
+
+## Issue 4: `v-model` on `<select multiple>` を実装する
+- **Status**: Open
+- **Priority**: Medium
+- **根拠**:
+  - compiler validate で `v-model on <select multiple> is not supported yet`
+- **対象ファイル（想定）**:
+  - `src/compiler/template/builder_validate.mbt`
+  - `src/compiler/codegen/attrs_binding.mbt`
+  - `src/compiler/snapshot/attrs_test.mbt`
+- **受け入れ条件**:
+  1. 複数選択値の配列同期
+  2. 初期選択状態の反映
+  3. snapshot test を追加
+
+## Issue 5: LSP completion と実装実態の差分監査
+- **Status**: Open
+- **Priority**: Low
+- **根拠**:
+  - completion で候補提示される directive と compile 対応範囲を定期チェックしたい
+- **対象ファイル（想定）**:
+  - `src/tooling/lsp_completion.mbt`
+  - `src/compiler/template/builder_validate.mbt`
+  - `src/tooling/tooling_lsp_test.mbt`
+- **受け入れ条件**:
+  1. completion 候補ごとのサポート状況表をテストで担保
+  2. 非対応機能は detail 表示で明示
+
+---
+
+## First action plan
+1. Issue 1（component-side `v-model`）の仕様を確定
+2. validate 制約を緩める
+3. codegen を追加
+4. snapshot test 追加

--- a/src/compiler/codegen/attrs_binding.mbt
+++ b/src/compiler/codegen/attrs_binding.mbt
@@ -106,13 +106,16 @@ fn render_client_model_attrs(
   match element.model {
     Some(model) if not(element.is_component) => {
       let checked = infer_model_checked(element)
-      let event_name = render_model_event_name(element, model, checked)
+      let radio = is_radio_model(element)
+      let event_name = render_model_event_name(element, model, checked || radio)
       let value_expr = if checked {
         "if " + model.expression + " { \"true\" } else { \"false\" }"
+      } else if radio {
+        "if " + render_radio_model_checked_expr(element, model) + " { \"true\" } else { \"false\" }"
       } else {
         model.expression + ".to_string()"
       }
-      let attr_name = if checked { "checked" } else { "value" }
+      let attr_name = if checked || radio { "checked" } else { "value" }
       if static_mode {
         parts.push("(\"" + attr_name + "\", @dom.attr(" + value_expr + "))")
       } else {
@@ -126,7 +129,7 @@ fn render_client_model_attrs(
         "\", @dom.on(fn(_event) { " +
         render_model_write_expr(
           model.expression,
-          render_model_read_expr(model, checked),
+          render_model_read_expr(model, checked || radio),
         ) +
         " }))",
       )
@@ -145,9 +148,12 @@ fn render_server_model_attrs(
   match element.model {
     Some(model) if not(element.is_component) => {
       let checked = infer_model_checked(element)
-      let attr_name = if checked { "checked" } else { "value" }
+      let radio = is_radio_model(element)
+      let attr_name = if checked || radio { "checked" } else { "value" }
       let value_expr = if checked {
         "if " + model.expression + " { \"true\" } else { \"false\" }"
+      } else if radio {
+        "if " + render_radio_model_checked_expr(element, model) + " { \"true\" } else { \"false\" }"
       } else {
         model.expression + ".to_string()"
       }
@@ -168,6 +174,40 @@ fn render_server_model_attrs(
     _ => ()
   }
   parts
+}
+
+///|
+fn is_radio_model(element : TemplateElement) -> Bool {
+  if element.tag != "input" {
+    return false
+  }
+  for attr in element.attrs {
+    if attr.name == "type" && attr.kind == Static && attr.value == "radio" {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn render_radio_model_checked_expr(element : TemplateElement, model : TemplateModel) -> String {
+  let mut candidate = "\"on\""
+  for attr in element.attrs {
+    if attr.name == "value" {
+      match attr.kind {
+        Static => {
+          candidate = quote(attr.value)
+          break
+        }
+        Dynamic => {
+          candidate = attr.value + ".to_string()"
+          break
+        }
+        _ => ()
+      }
+    }
+  }
+  model.expression + ".to_string() == " + candidate
 }
 
 ///|

--- a/src/compiler/snapshot/attrs_test.mbt
+++ b/src/compiler/snapshot/attrs_test.mbt
@@ -242,3 +242,57 @@ test "v-model rewrites spaced getter targets from AST" {
   )
   assert_false(output.client_code.contains("get () ="))
 }
+
+///|
+test "component v-model compiles to modelValue prop" {
+  let source =
+    #|<script setup>
+    #|import {
+    #|  "mizchi/luna/js/resource" @reactivity,
+    #|  let signal = @reactivity.signal,
+    #|}
+    #|
+    #|let name = signal("hello")
+    #|</script>
+    #|
+    #|<template>
+    #|  <MyInput v-model='name.get()' />
+    #|</template>
+  let output = compile(source, filename="examples/component_model.mbtv") catch {
+    err => {
+      ignore(err)
+      panic()
+    }
+  }
+  assert_true(output.client_code.contains("(\"modelValue\", fn() { name.get().to_string() })"))
+  assert_true(output.server_code.contains("(\"modelValue\", name.get().to_string())"))
+}
+
+///|
+test "snapshot v-model radio compile" {
+  let source =
+    #|<script setup>
+    #|import {
+    #|  "mizchi/luna/js/resource" @reactivity,
+    #|  let signal = @reactivity.signal,
+    #|}
+    #|
+    #|let picked = signal("b")
+    #|</script>
+    #|
+    #|<template>
+    #|  <form>
+    #|    <input type='radio' value='a' v-model='picked.get()' />
+    #|    <input type='radio' value='b' v-model='picked.get()' />
+    #|  </form>
+    #|</template>
+  let output = compile(source, filename="examples/model_radio.mbtv") catch {
+    err => {
+      ignore(err)
+      panic()
+    }
+  }
+  assert_true(output.client_code.contains("(\"checked\", @dom.dynAttr(fn() { if picked.get().to_string() == \"a\" { \"true\" } else { \"false\" } }))"))
+  assert_true(output.client_code.contains("(\"checked\", @dom.dynAttr(fn() { if picked.get().to_string() == \"b\" { \"true\" } else { \"false\" } }))"))
+  assert_true(output.client_code.contains("picked.set(_event._get(\"target\")._get(\"value\").cast())"))
+}

--- a/src/compiler/template/builder_validate.mbt
+++ b/src/compiler/template/builder_validate.mbt
@@ -204,9 +204,11 @@ fn validate_native_model_binding(
     }
     match find_static_attr_value(attrs, "type") {
       Some("radio") =>
-        raise CompilerError::InvalidDirective(
-          "v-model on <input type=\"radio\"> is not supported yet",
-        )
+        if has_model_modifier_name(model, "trim") {
+          raise CompilerError::InvalidDirective(
+            "unsupported v-model modifier `.trim` on <input type=\"radio\">",
+          )
+        }
       Some("file") =>
         raise CompilerError::InvalidDirective(
           "v-model on <input type=\"file\"> is not supported yet",
@@ -235,6 +237,19 @@ fn validate_native_model_binding(
 }
 
 ///|
+
+///|
+fn validate_component_model_binding(
+  tag : String,
+  model : TemplateModel,
+) -> Unit raise CompilerError {
+  for modifier in model.modifiers {
+    raise CompilerError::InvalidDirective(
+      "component v-model modifiers are not supported yet on <\{tag}>: `.\{modifier}`",
+    )
+  }
+}
+
 fn occupied_directive_value(target : String?) -> String? {
   match target {
     Some(_) => Some("used")
@@ -323,10 +338,7 @@ fn validate_component_bindings(
     None => ()
   }
   match model {
-    Some(_) =>
-      raise CompilerError::InvalidDirective(
-        "component v-model is not supported yet on <\{tag}>",
-      )
+    Some(binding) => validate_component_model_binding(tag, binding)
     None => ()
   }
 }


### PR DESCRIPTION
### Motivation
- Enable component-side `v-model` and implement `v-model` behavior for `<input type="radio">` which were previously rejected by validation, and capture outstanding work in a new backlog document.
- Update codegen to properly render `checked` state and write handlers for radio inputs so template output reflects intended runtime behavior.

### Description
- Relax template validation for component model bindings by adding `validate_component_model_binding` in `src/compiler/template/builder_validate.mbt` and reject only unsupported modifiers on component `v-model` instead of wholesale rejection. 
- Allow `v-model` on radio inputs while disallowing `.trim` on radio (and preserve the existing restrictions for `file`, `checkbox`, and `select multiple`) in `builder_validate.mbt`.
- Implement radio-specific model handling in `src/compiler/codegen/attrs_binding.mbt` by adding `is_radio_model` and `render_radio_model_checked_expr` and updating client/server model attribute rendering so radio inputs use `checked` and the correct read/write expressions and event names. 
- Add snapshot compiler tests in `src/compiler/snapshot/attrs_test.mbt` covering component `v-model` compilation to `modelValue` and radio `v-model` output, and add a new `docs/ISSUES.md` containing an implementation backlog and action plan.

### Testing
- Ran the compiler snapshot tests updated in `src/compiler/snapshot/attrs_test.mbt`, including the new tests for component `v-model` and radio `v-model`, and they passed.
- Ran the existing snapshot assertion that verifies spaced getter rewriting (`v-model rewrites spaced getter targets from AST`) and it continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c83603c48321aeb9f974160b865c)