### PR TITLE
docs: document v-unsafe-html trust boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,10 @@ Today the template layer supports:
 - component-looking tags via uppercase names
 - scoped styles
 
+`v-unsafe-html` is an explicit escape hatch. Vapor Moon does not sanitize this
+content; pass only trusted or already-sanitized HTML, and do not bind
+user-controlled strings directly to it.
+
 Island and delivery directives are part of the template surface:
 
 - `client:load`


### PR DESCRIPTION
## Summary
- documents `v-unsafe-html` as an explicit trust-boundary escape hatch
- warns that Vapor Moon does not sanitize raw HTML and user-controlled strings should not be bound directly

Closes #62.

## Validation
- `git diff --check`
- pre-commit hook ran Moon checks/tests during commit
