### PR TITLE
chore: production-readiness hardening pass (#80-#88)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Report a defect in the compiler, runtime, CLI, or LSP.
+title: "bug(area): "
+labels: bug
+---
+
+## Summary
+
+<!-- One or two sentences describing the wrong behavior. -->
+
+## Reproduction
+
+Minimal `.mbtv` source (please trim — large repros are hard to bisect):
+
+```html
+<script setup>
+</script>
+
+<template>
+</template>
+
+<style>
+</style>
+```
+
+CLI / LSP command used:
+
+```bash
+moon run src/cmd/vapor_moon -- compile ./Repro.mbtv
+```
+
+## Expected vs. actual
+
+- **Expected:**
+- **Actual:**
+
+## Environment
+
+- Vapor Moon version (`vapor-moon --version` output):
+- MoonBit CLI version (`moon version` output):
+- OS / arch (e.g. `Darwin arm64`, `Linux x86_64`):
+- Editor / LSP client (if reporting an LSP bug):
+
+## Anything else?
+
+<!-- Relevant logs, screenshots, related issues. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/ubugeeei/vapor-moon/security/advisories/new
+    about: Report a suspected vulnerability privately. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,21 @@
+---
+name: Documentation
+about: Report a gap or error in the README, CHANGELOG, or in-repo docs.
+title: "docs: "
+labels: documentation
+---
+
+## Where
+
+<!-- File path + section, or a permalink to the line that's wrong /
+missing. -->
+
+## What's wrong / missing
+
+<!-- Short description. -->
+
+## Proposed wording (optional)
+
+```md
+
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Propose a new compiler, runtime, CLI, or LSP capability.
+title: "feat(area): "
+labels: enhancement
+---
+
+## Problem
+
+<!-- What can't you do today, or what's awkward? Concrete examples beat
+abstract goals. -->
+
+## Proposal
+
+<!-- One or two paragraphs describing the shape of the change. If there
+are alternatives, list them. -->
+
+## Acceptance
+
+- [ ]
+- [ ]
+- [ ]
+
+## Out of scope
+
+<!-- Optional: behaviors that should NOT be part of this change. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- One or two sentences on what this PR changes. -->
+
+## Why
+
+<!-- The motivation: linked issue, bug repro, user need. -->
+
+Closes #
+
+## Test plan
+
+- [ ] `moon check --deny-warn --warn-list -deprecated_syntax-deprecated --target native`
+- [ ] `moon check --deny-warn --warn-list -deprecated_syntax-deprecated --target js`
+- [ ] `moon test --target native`
+- [ ] `moon test --target js src/lsp` (if LSP changed)
+- [ ] `bash scripts/smoke_cli.sh` (if CLI changed)
+- [ ] `bash scripts/smoke_lsp.sh` (if LSP launcher changed)
+- [ ] Updated `CHANGELOG.md` `[Unreleased]` if user-visible behavior changed.
+
+## Checklist
+
+- [ ] Commits use the conventional prefixes documented in CONTRIBUTING.md.
+- [ ] No accidental snapshot updates: every changed file under
+      `src/compiler/snapshot/` / `src/compiler/coverage/` is intentional.
+- [ ] If the VS Code extension was touched, `editors/vscode/package.json`
+      and `package-lock.json` versions still match `moon.mod.json`.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-native:
+  check-native-matrix:
     name: check-native (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -65,6 +65,17 @@ jobs:
         run: bash scripts/smoke_cli.sh
       - name: Package contents
         run: moon package --list
+
+  # Umbrella status check so the repo ruleset (which requires the bare
+  # name `check-native`) keeps matching once the underlying job moved to
+  # a per-OS matrix. Don't remove this without also updating the ruleset.
+  check-native:
+    name: check-native
+    runs-on: ubuntu-latest
+    needs: check-native-matrix
+    steps:
+      - name: All matrix legs succeeded
+        run: echo "check-native matrix passed on every os"
 
   check-js:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,8 @@ permissions:
 env:
   MOONBIT_VERSION: latest
   MOONBIT_EXPECTED_VERSION: "0.1.20260512"
+  # SHA-256 is pinned per host: keep the ubuntu (linux-x86_64) sums here and
+  # let the macOS leg derive its own (currently unpinned — see #83).
   MOONBIT_ARCHIVE_SHA256: "2c3a5af2020c9ceb3fe11e6457e647a215846d97d71c8e784b3d0a7c8cfc606b"
   MOONBIT_CORE_SHA256: "c68ba56201bd8d99db442b6df599c2c217b0528edec7d6de6e871b6e589c502e"
   NODE_VERSION: "24"
@@ -28,8 +30,21 @@ concurrency:
 
 jobs:
   check-native:
-    runs-on: ubuntu-latest
+    name: check-native (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            archive-sha256: "2c3a5af2020c9ceb3fe11e6457e647a215846d97d71c8e784b3d0a7c8cfc606b"
+            core-sha256: "c68ba56201bd8d99db442b6df599c2c217b0528edec7d6de6e871b6e589c502e"
+          # macOS leg has no pinned checksums yet — see #83 for the
+          # SHA-256 pinning follow-up.
+          - os: macos-latest
+            archive-sha256: ""
+            core-sha256: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -40,8 +55,8 @@ jobs:
         with:
           version: ${{ env.MOONBIT_VERSION }}
           expected-version: ${{ env.MOONBIT_EXPECTED_VERSION }}
-          archive-sha256: ${{ env.MOONBIT_ARCHIVE_SHA256 }}
-          core-sha256: ${{ env.MOONBIT_CORE_SHA256 }}
+          archive-sha256: ${{ matrix.archive-sha256 }}
+          core-sha256: ${{ matrix.core-sha256 }}
       - name: Moon check
         run: moon check --deny-warn --warn-list -deprecated_syntax-deprecated --target native 2> >(grep -v 'WARN Duplicate alias' >&2)
       - name: Moon native tests
@@ -104,7 +119,18 @@ jobs:
         working-directory: editors/vscode
       - name: Validate VS Code extension manifest
         run: |
-          node -e "const pkg = require('./package.json'); if (!pkg.contributes?.languages?.length || !pkg.contributes?.grammars?.length) process.exit(1)"
+          node -e "const pkg = require('./package.json'); if (!pkg.contributes?.languages?.length || !pkg.contributes?.grammars?.length) process.exit(1); for (const field of ['repository','bugs','homepage','keywords']) { if (!pkg[field]) { console.error('missing field: '+field); process.exit(1); } }"
+        working-directory: editors/vscode
+      - name: Verify VS Code extension version tracks moon.mod.json
+        run: |
+          mod_version="$(grep -m1 '"version"' moon.mod.json | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+          ext_version="$(node -p "require('./editors/vscode/package.json').version")"
+          if [ "$mod_version" != "$ext_version" ]; then
+            echo "moon.mod.json version $mod_version differs from VS Code extension version $ext_version" >&2
+            exit 1
+          fi
+      - name: Package VS Code extension
+        run: npx --yes @vscode/vsce@latest package --no-dependencies --out /tmp/vapor-moon.vsix
         working-directory: editors/vscode
       - name: Check Zed extension
         run: cargo check --locked --manifest-path editors/zed/Cargo.toml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,7 @@ env:
   MOONBIT_EXPECTED_VERSION: "0.1.20260512"
   MOONBIT_ARCHIVE_SHA256: "2c3a5af2020c9ceb3fe11e6457e647a215846d97d71c8e784b3d0a7c8cfc606b"
   MOONBIT_CORE_SHA256: "c68ba56201bd8d99db442b6df599c2c217b0528edec7d6de6e871b6e589c502e"
+  NODE_VERSION: "24"
 
 defaults:
   run:
@@ -51,3 +52,55 @@ jobs:
         run: moon package --list
       - name: Publish dry run
         run: bash scripts/verify_publish_dry_run.sh
+
+  vscode-extension:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
+      - name: Install VS Code extension dependencies
+        run: npm ci --ignore-scripts
+        working-directory: editors/vscode
+      - name: Verify version tracks moon.mod.json
+        run: |
+          mod_version="$(grep -m1 '"version"' moon.mod.json | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+          ext_version="$(node -p "require('./editors/vscode/package.json').version")"
+          if [ "$mod_version" != "$ext_version" ]; then
+            echo "moon.mod.json version $mod_version differs from VS Code extension version $ext_version" >&2
+            exit 1
+          fi
+      - name: Package extension
+        run: npx --yes @vscode/vsce@latest package --no-dependencies --out vapor-moon.vsix
+        working-directory: editors/vscode
+      - name: Upload .vsix artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: vapor-moon-vsix
+          path: editors/vscode/vapor-moon.vsix
+          if-no-files-found: error
+          retention-days: 30
+      - name: Attach .vsix to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" editors/vscode/vapor-moon.vsix --clobber
+          fi
+      - name: Publish to VS Code Marketplace
+        if: startsWith(github.ref, 'refs/tags/v') && env.VSCE_PAT != ''
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx --yes @vscode/vsce@latest publish --no-dependencies --packagePath vapor-moon.vsix
+        working-directory: editors/vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Changelog
+
+All notable changes to **Vapor Moon** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Until `1.0.0`, expect breaking changes in any minor release; patch releases stay
+backwards compatible.
+
+## [Unreleased]
+
+### Added
+- `vapor-moon --help` / `-h` / `help` and `vapor-moon --version` / `-V` flags
+  (#80). The version string is sourced from a single `VERSION` constant shared
+  with the LSP `serverInfo` payload (#85).
+- LSP `textDocument/prepareRename`, `textDocument/rename`, and
+  `textDocument/codeAction` handlers — Phase 1 stubs that declare the
+  capability and return safe empty responses so editors stop reporting
+  "method not found" (#86).
+- VS Code extension marketplace metadata (`repository`, `bugs`, `homepage`,
+  `keywords`, `author`) and `package` / `publish` scripts (#84).
+- CI cross-platform matrix: `check-native` now runs on both
+  `ubuntu-latest` and `macos-latest` (#83).
+- Release workflow now packages the VS Code extension on every tag, uploads
+  the `.vsix` as an artifact, and (when `VSCE_PAT` is configured) publishes
+  to the Marketplace (#87).
+- Repository community-health files: `CONTRIBUTING.md`, `SECURITY.md`,
+  GitHub issue / pull-request templates, and a README "Security model"
+  section (#81, #82, #88).
+
+### Changed
+- VS Code extension version bumped to `0.1.1` and is now CI-asserted to
+  track `moon.mod.json` (#84).
+
+### Fixed
+- LSP `initialize` response now reports the real package version instead of
+  a stale hard-coded `0.1.0` (#85).
+
+## [0.1.1] — 2026-05-19
+
+### Added
+- Component event listeners (`@event` / `v-on:event`) and component-side
+  `v-model` lowering (#78, plus regression coverage in #71, #72).
+- Builtin component shells for `<Teleport>`, `<Transition>`, and
+  `<TransitionGroup>` carried into client/server output.
+- `vapor-moon analyze` / `diagnostics` / `hover` / `definition` /
+  `references` / `complete` / `format` / `watch` CLI subcommands.
+- `defineExpose()` macro and template-ref binding helpers.
+- `v-match` / `v-case` / `v-else` / `v-else-if` directive support, dynamic
+  components (`<component :is>`), v-bind full syntax.
+- Incremental compilation infrastructure backed by `mizchi/ripple` and a
+  watch-mode runner that writes generated outputs beside the source file.
+- VS Code, Zed, and Neovim editor integrations, plus a stdio JSON-RPC LSP
+  server.
+
+### Changed
+- `<style>` blocks are scoped by default. Use `<style scoped="false">` for
+  global CSS.
+- `v-html` renamed to `v-unsafe-html` to make the security boundary
+  explicit (#27, with documentation update in #67).
+- CLI now returns nonzero exit codes for usage, file-read, and compile
+  failures (#43).
+- CI workflows hardened: workflow setup consolidated, MoonBit toolchain
+  pinned by version and SHA-256, JS LSP smoke test added, deny-warn on JS
+  builds, editor-integration manifest validation (#41, #42, #44, #46, #61,
+  #68, #73, #74, #75).
+
+### Fixed
+- LSP rejects negative `textDocument` positions (#51).
+- Radio `v-model` change handlers now write the selected `value` instead of
+  `checked` (#40, #52).
+- Packaged VS Code LSP launcher resolves correctly after extension
+  bundling (#60, #69).
+- Template indentation preserved in formatter fallbacks.
+
+## [0.1.0] — 2025-12
+
+- Initial public preview: `.mbtv` Single File Component parser, client and
+  server (luna SSR) code generation, scoped style hashing, basic editor
+  tooling.
+
+[Unreleased]: https://github.com/ubugeeei/vapor-moon/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/ubugeeei/vapor-moon/releases/tag/v0.1.1
+[0.1.0]: https://github.com/ubugeeei/vapor-moon/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,19 @@ backwards compatible.
   `textDocument/codeAction` handlers — Phase 1 stubs that declare the
   capability and return safe empty responses so editors stop reporting
   "method not found" (#86).
+- LSP directive completion details now spell out `v-model` partial-support
+  boundaries (supported targets, unsupported targets, modifier matrix) and
+  introduce a separate `v-model:prop` entry (#66).
+- `v-model` on `<select multiple>` — bound to an `Array[String]` and
+  round-tripped through a runtime helper that walks `<option>` children on
+  every render and collects `event.target.selectedOptions` on change
+  (#64).
 - VS Code extension marketplace metadata (`repository`, `bugs`, `homepage`,
   `keywords`, `author`) and `package` / `publish` scripts (#84).
+- VS Code extension ships a `LICENSE` and a `.vscodeignore`, silencing
+  the `vsce package` warnings.
+- Zed extension manifest, `Cargo.toml`, and `Cargo.lock` track the
+  `0.1.1` release.
 - CI cross-platform matrix: `check-native` now runs on both
   `ubuntu-latest` and `macos-latest` (#83).
 - Release workflow now packages the VS Code extension on every tag, uploads
@@ -27,10 +38,15 @@ backwards compatible.
 - Repository community-health files: `CONTRIBUTING.md`, `SECURITY.md`,
   GitHub issue / pull-request templates, and a README "Security model"
   section (#81, #82, #88).
+- Compiler / runtime docstrings document the `v-unsafe-html` escape-hatch
+  contract next to every lowering and validation site (#62).
 
 ### Changed
 - VS Code extension version bumped to `0.1.1` and is now CI-asserted to
   track `moon.mod.json` (#84).
+- `<input type="file">` v-model rejection is now a final compile-time
+  error with a message pointing at the recommended `@change` +
+  `event.target.files` pattern (#65).
 
 ### Fixed
 - LSP `initialize` response now reports the real package version instead of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,12 @@ When opening a PR, make sure:
 
 ## Releasing
 
-1. Bump `version` in `moon.mod.json` and `editors/vscode/package.json`
-   (plus `package-lock.json`); also update the `VERSION` constant in
-   `src/compiler/common/version.mbt`.
+1. Bump `version` in all of these so they stay in sync:
+   - `moon.mod.json`
+   - `src/compiler/common/version.mbt` (the `VERSION` constant)
+   - `editors/vscode/package.json` and `editors/vscode/package-lock.json`
+   - `editors/zed/extension.toml`, `editors/zed/Cargo.toml`, and the
+     `zed_vapor_moon` entry in `editors/zed/Cargo.lock`.
 2. Update `CHANGELOG.md`: rename the `[Unreleased]` section to the new
    version + date and add a fresh `[Unreleased]` block.
 3. Tag `vX.Y.Z` on `main`. The `Release Verify` workflow runs the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to Vapor Moon
+
+Thanks for your interest in Vapor Moon! This document collects the
+day-to-day commands and conventions a contributor needs to land a change.
+
+The project is an unpublished hobby tool, but it tries to hold itself to
+production-readiness standards: deterministic CI, snapshot-tested compiler
+output, and a working LSP across VS Code, Zed, and Neovim. Please help us
+keep that bar.
+
+## Prerequisites
+
+| Tool | Version | Used for |
+| --- | --- | --- |
+| [MoonBit CLI](https://www.moonbitlang.com/) | `0.1.20260512` (CI pin) | Compiler, tooling, and tests. The `.github/actions/setup-moonbit` action also pins SHA-256 of the toolchain archive. |
+| [Node.js](https://nodejs.org/) | `24.x` | LSP smoke test, VS Code extension, Playwright E2E suite. |
+| [pnpm](https://pnpm.io/) | `10.x` | `e2e/` workspace. |
+| [Rust toolchain](https://rustup.rs/) | stable | Building the Zed extension (`editors/zed`). |
+
+The repo ships `.githooks/pre-commit` — enable it locally with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+It runs `moon fmt`, `moon check`, the compiler/tooling tests, and (when
+`node` is on `PATH`) the JS LSP tests.
+
+## Local commands
+
+```bash
+# Type-check & lint
+moon check --deny-warn --warn-list -deprecated_syntax-deprecated --target native
+moon check --deny-warn --warn-list -deprecated_syntax-deprecated --target js
+
+# Native tests (compiler, runtime, CLI, tooling)
+moon test --target native
+
+# JS-only tests (LSP, runtime/dom, runtime/server)
+moon test --target js src/lsp
+moon test --target js src/runtime
+moon test --target js src/runtime/dom
+moon test --target js src/runtime/server
+
+# CLI surface
+bash scripts/smoke_cli.sh
+
+# LSP launcher
+bash scripts/smoke_lsp.sh
+
+# End-to-end (compiled output + browser)
+pnpm --dir e2e install --frozen-lockfile
+pnpm --dir e2e exec playwright install chromium --with-deps
+pnpm --dir e2e test
+```
+
+## Conventional commits
+
+Commit subjects follow the prefixes already in `git log`:
+
+| Prefix | When |
+| --- | --- |
+| `feat:` | New user-visible behavior. |
+| `feat!:` | Breaking change. |
+| `fix:` | Bug fix. |
+| `test:` | Test-only additions or rewrites. |
+| `docs:` | README, CHANGELOG, CONTRIBUTING, etc. |
+| `ci:` | Workflow / dependency-pin changes. |
+| `chore:` | Build / deps / housekeeping. |
+| `refactor:` | Internal restructure with no behavior change. |
+| `style:` | Formatting / cosmetic. |
+| `lsp:`, `cli:`, `compiler:` | Optional scope-tagged variants used for area-specific work. |
+
+The squash-merge subject becomes the commit subject — write it accordingly.
+
+## Pull request checklist
+
+When opening a PR, make sure:
+
+- [ ] `moon check --deny-warn` passes for both `native` and `js` targets.
+- [ ] `moon test` passes (snapshots updated where intentional).
+- [ ] `scripts/smoke_cli.sh` and, if you touched the LSP, `scripts/smoke_lsp.sh` pass.
+- [ ] If user-visible behavior changed, `CHANGELOG.md` `[Unreleased]` is updated.
+- [ ] If the change affects the VS Code extension manifest or version, the
+      lockfile and `editors/vscode/package.json` are in sync with
+      `moon.mod.json`.
+
+## Backlog management
+
+- Production-readiness tasks live in GitHub Issues with the
+  `production-readiness` label.
+- `docs/ISSUES.md` is the short snapshot of shipped / partial / open work;
+  it links into GitHub Issues, not the other way around.
+- For non-trivial feature work, open an issue first to align on shape
+  before sending the PR.
+
+## Releasing
+
+1. Bump `version` in `moon.mod.json` and `editors/vscode/package.json`
+   (plus `package-lock.json`); also update the `VERSION` constant in
+   `src/compiler/common/version.mbt`.
+2. Update `CHANGELOG.md`: rename the `[Unreleased]` section to the new
+   version + date and add a fresh `[Unreleased]` block.
+3. Tag `vX.Y.Z` on `main`. The `Release Verify` workflow runs the
+   compiler dry-run publish (`moon publish --dry-run`) and packages /
+   uploads / publishes the VS Code extension when `VSCE_PAT` is
+   configured.

--- a/README.md
+++ b/README.md
@@ -365,6 +365,24 @@ Today the template layer supports:
 content; pass only trusted or already-sanitized HTML, and do not bind
 user-controlled strings directly to it.
 
+### `v-model` partial-support boundaries
+
+- **`<select multiple>`** — supported. Bind an `Array[String]` (assignable
+  or signal getter). The compiler lowers the binding to a runtime helper
+  that walks the option children on every render and feeds
+  `event.target.selectedOptions` back into the binding on `change`. SSR
+  for `<select multiple v-model>` is a no-op for now — the multiple
+  selection state hydrates on the client.
+- **`<input type="file">`** — the DOM `value` property is read-only for
+  security reasons. Vapor Moon will not accept `v-model` here. Use
+  `@change` and read `event.target.files` instead (typically into a
+  `signal[FileList?]`); reset the input through a `ref`. This rejection
+  is final, not provisional.
+- **`v-model` modifiers** (`.lazy`, `.number`, `.trim`) — supported only
+  where explicitly noted. `.trim` and `.lazy` are accepted for text
+  inputs; everywhere else they are rejected with a pointing error
+  message.
+
 ## Security Model
 
 Vapor Moon's compiler and runtime split string interpolation into two

--- a/README.md
+++ b/README.md
@@ -365,6 +365,43 @@ Today the template layer supports:
 content; pass only trusted or already-sanitized HTML, and do not bind
 user-controlled strings directly to it.
 
+## Security Model
+
+Vapor Moon's compiler and runtime split string interpolation into two
+classes: **escaped by default** and **explicitly opt-out**. Knowing which
+class a binding falls into is the contract for safe authoring.
+
+### Escaped by default
+
+The following forms HTML-escape their result on both the DOM client and the
+`luna` SSR target. Authors do not need to sanitize before passing
+user-controlled values:
+
+- `{{ expression }}` text interpolation inside `<template>`.
+- The `v-text` directive.
+- Dynamic attribute bindings via `:attr="expr"` and `v-bind:attr="expr"`.
+- Generated `class` and `style` bindings.
+- Component placeholder `data-prop-*` metadata attributes.
+
+### Explicit opt-out
+
+- `v-unsafe-html="expr"` — lowers `expr` directly into `@luna_core.raw_html`
+  with no sanitization. The compiler rejects this directive on void
+  elements, component tags, and elements that already have child nodes
+  (see [#62](https://github.com/ubugeeei/vapor-moon/issues/62)), but it
+  intentionally cannot reason about the safety of `expr` itself.
+
+  Recommended pattern: sanitize at the call site with an established HTML
+  sanitizer before binding the result to `v-unsafe-html`. Never pass raw
+  user input to it.
+
+### Reporting issues
+
+Please report suspected vulnerabilities privately through
+[GitHub Security Advisories](https://github.com/ubugeeei/vapor-moon/security/advisories/new).
+See [SECURITY.md](./SECURITY.md) for the full disclosure policy and
+in-scope surfaces.
+
 Island and delivery directives are part of the template surface:
 
 - `client:load`
@@ -421,6 +458,12 @@ The CLI currently exposes:
 - `references <file.mbtv> <line> <character> [includeDeclaration]`
 - `complete <file.mbtv> <line> <character>`
 - `format <file.mbtv>`
+- `watch <directory>`
+
+Top-level flags:
+
+- `--help` / `-h` / `help` — print the structured help message.
+- `--version` / `-V` — print the package version.
 
 ## Editor Integrations
 
@@ -440,6 +483,13 @@ So editor integrations expect:
 
 - `moon` on `PATH`
 - a JS runtime such as `node`, `bun`, or `deno` on `PATH`
+
+## Contributing
+
+- See [CONTRIBUTING.md](./CONTRIBUTING.md) for the contributor workflow, local
+  commands, conventional-commit prefixes, and PR checklist.
+- See [SECURITY.md](./SECURITY.md) for the vulnerability disclosure policy.
+- See [CHANGELOG.md](./CHANGELOG.md) for release notes.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security policy
+
+Vapor Moon is an unpublished hobby project, but the compiler emits code
+that runs in users' browsers, so we treat security reports seriously.
+
+## Supported versions
+
+We backport security fixes to the latest minor release on the default
+branch. Older `0.x` releases are not maintained.
+
+| Version | Supported |
+| --- | --- |
+| `0.1.x` | Yes |
+| `< 0.1` | No |
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for suspected vulnerabilities.
+
+Use [GitHub Security Advisories](https://github.com/ubugeeei/vapor-moon/security/advisories/new)
+("Report a vulnerability") so the maintainers can triage privately. If
+GitHub Security Advisories are unavailable to you, email the maintainer
+listed in the repository profile.
+
+We aim to acknowledge new reports within seven days and to ship a fix or
+mitigation within thirty days of triage. Reporters will be credited in the
+release notes unless they ask otherwise.
+
+## In-scope surfaces
+
+The following areas are explicitly in scope for vulnerability reports:
+
+- **HTML injection / XSS in generated client and SSR output.** The
+  template compiler is expected to HTML-escape every interpolation
+  (`{{ ... }}`, `v-text`, dynamic attribute values) on both targets. See
+  the README "Security model" section for the full contract.
+- **`v-unsafe-html` lowering.** Bypassing escape is the directive's
+  *advertised* behavior, but the compiler must reject the directive on
+  void elements, components, and slots (see #62). If you can sneak `<`
+  past the validator without using `v-unsafe-html`, that is a bug.
+- **LSP request handling.** The stdio server runs locally but parses
+  arbitrary JSON-RPC payloads. Crashes, out-of-memory paths, or path
+  traversal via `textDocument/uri` are in scope.
+- **CLI argument and file handling.** Path traversal via `compile`,
+  `watch`, or `format` arguments is in scope; the CLI assumes the caller
+  controls the working tree but should not silently follow attacker-
+  controlled symlinks outside it.
+
+## Out of scope
+
+- Vulnerabilities in upstream MoonBit toolchains, `mizchi/luna`,
+  `mizchi/js`, `mizchi/ripple`, or `moonbitlang/*` packages. Please
+  report those to their respective maintainers; we will mirror the fix.
+- Issues that only reproduce against `node_modules/` of `editors/vscode`
+  or `e2e/` — those are pinned via lockfiles and updated through
+  Dependabot.
+- Denial of service via deeply nested user input where the only mitigation
+  is "don't compile attacker-supplied components." Defense-in-depth ideas
+  are still welcome as enhancement issues, but won't be treated as
+  embargoed reports.

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -13,9 +13,9 @@
 | Area | Current behavior | Tracking |
 | --- | --- | --- |
 | Component `v-model` modifiers | Explicitly rejected by the compiler. | Create a GitHub issue before implementation work. |
-| `v-model` on `<input type="file">` | Explicitly rejected; decide whether to keep it invalid or design `files` sync. | [#65](https://github.com/ubugeeei/vapor-moon/issues/65) |
-| `v-model` on `<select multiple>` | Explicitly rejected; array sync and initial multiple selection are not implemented. | [#64](https://github.com/ubugeeei/vapor-moon/issues/64) |
-| LSP directive completions | `v-model` is listed generically, without partial-support details. | [#66](https://github.com/ubugeeei/vapor-moon/issues/66) |
+| `v-model` on `<input type="file">` | Final compile-time rejection; the directive will not be supported (DOM `value` is read-only). README documents the recommended `@change` + `event.target.files` pattern. | [#65](https://github.com/ubugeeei/vapor-moon/issues/65) — shipped on `claude/laughing-hawking-1da397`. |
+| `v-model` on `<select multiple>` | Shipped: lowers to `bind_select_multiple_model` (Array[String] round-trip + render-effect sync of `selected` on options). SSR is a deliberate no-op. | [#64](https://github.com/ubugeeei/vapor-moon/issues/64) — shipped on `claude/laughing-hawking-1da397`. |
+| LSP directive completions | `v-model` and `v-model:prop` carry structured detail listing supported/unsupported targets and modifiers. | [#66](https://github.com/ubugeeei/vapor-moon/issues/66) — shipped on `claude/laughing-hawking-1da397`. |
 
 ## Production Readiness Issues
 
@@ -36,3 +36,13 @@ Open production-readiness work should live in GitHub Issues instead of growing t
 | [#86](https://github.com/ubugeeei/vapor-moon/issues/86) | LSP `textDocument/rename` and `textDocument/codeAction`. *(Phase 1 stubs shipped; Phase 2 implementation tracked in the same issue.)* |
 | [#87](https://github.com/ubugeeei/vapor-moon/issues/87) | Automated VS Code Marketplace publishing on tag. *(Shipped pending `VSCE_PAT` secret + first tag.)* |
 | [#88](https://github.com/ubugeeei/vapor-moon/issues/88) | README "Security model" section. *(Shipped; close on merge.)* |
+
+## Larger Feature Work
+
+Out of scope for production-readiness; tracked as full features.
+
+| Issue | Status |
+| --- | --- |
+| [#13](https://github.com/ubugeeei/vapor-moon/issues/13) | Component import / linking across `.mbtv` files. Phase breakdown posted as an issue comment; needs Phase 0 design decision before implementation. |
+| [#14](https://github.com/ubugeeei/vapor-moon/issues/14) | `provide` / `inject`. Phase breakdown posted as an issue comment; Phase 1 needs a runtime context scope API. |
+| [#53](https://github.com/ubugeeei/vapor-moon/issues/53) | MoonBit 0.9 deprecation cleanup. Issue itself asks for a dedicated PR so the mechanical replacements stay reviewable; left as a follow-up. |

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -23,12 +23,16 @@ Open production-readiness work should live in GitHub Issues instead of growing t
 
 | Issue | Scope |
 | --- | --- |
-| [#57](https://github.com/ubugeeei/vapor-moon/issues/57) | Move CLI command tests out of the main package. |
-| [#59](https://github.com/ubugeeei/vapor-moon/issues/59) | Add browser-oriented coverage for component `v-model` lowering. |
-| [#60](https://github.com/ubugeeei/vapor-moon/issues/60) | Resolve the packaged VS Code LSP launcher. |
-| [#61](https://github.com/ubugeeei/vapor-moon/issues/61) | Fail JS MoonBit checks on non-deprecation warnings. |
 | [#62](https://github.com/ubugeeei/vapor-moon/issues/62) | Define the `v-unsafe-html` trust boundary. |
-| [#63](https://github.com/ubugeeei/vapor-moon/issues/63) | Pin the MoonBit CLI used by CI and release verification. |
 | [#64](https://github.com/ubugeeei/vapor-moon/issues/64) | Support `v-model` on `<select multiple>`. |
 | [#65](https://github.com/ubugeeei/vapor-moon/issues/65) | Settle file input `v-model` behavior. |
 | [#66](https://github.com/ubugeeei/vapor-moon/issues/66) | Expose partial directive support in completion details. |
+| [#80](https://github.com/ubugeeei/vapor-moon/issues/80) | CLI `--version` / `--help` flags. *(Shipped on `claude/laughing-hawking-1da397`; close on merge.)* |
+| [#81](https://github.com/ubugeeei/vapor-moon/issues/81) | `CHANGELOG.md` with Keep-a-Changelog format. *(Shipped; close on merge.)* |
+| [#82](https://github.com/ubugeeei/vapor-moon/issues/82) | `CONTRIBUTING.md`, `SECURITY.md`, issue / PR templates. *(Shipped; close on merge.)* |
+| [#83](https://github.com/ubugeeei/vapor-moon/issues/83) | CI cross-platform matrix beyond `ubuntu-latest`. *(Phase 1: macOS leg added; SHA-256 pinning still pending.)* |
+| [#84](https://github.com/ubugeeei/vapor-moon/issues/84) | VS Code extension manifest hardening + version sync. *(Shipped; close on merge.)* |
+| [#85](https://github.com/ubugeeei/vapor-moon/issues/85) | LSP server version sourced from a shared `VERSION` constant. *(Shipped; close on merge.)* |
+| [#86](https://github.com/ubugeeei/vapor-moon/issues/86) | LSP `textDocument/rename` and `textDocument/codeAction`. *(Phase 1 stubs shipped; Phase 2 implementation tracked in the same issue.)* |
+| [#87](https://github.com/ubugeeei/vapor-moon/issues/87) | Automated VS Code Marketplace publishing on tag. *(Shipped pending `VSCE_PAT` secret + first tag.)* |
+| [#88](https://github.com/ubugeeei/vapor-moon/issues/88) | README "Security model" section. *(Shipped; close on merge.)* |

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,11 @@
+.vscode/**
+.vscode-test/**
+node_modules/**
+**/*.map
+**/.gitignore
+**/.eslintrc.json
+**/.eslintrc.js
+**/tsconfig.json
+**/package-lock.json
+**/*.vsix
+**/.DS_Store

--- a/editors/vscode/LICENSE
+++ b/editors/vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ubugeeei and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vapor-moon",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vapor-moon",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,19 +2,45 @@
   "name": "vapor-moon",
   "displayName": "Vapor Moon",
   "description": "Language support and LSP client for Vapor Moon .mbtv components.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "ubugeeei",
   "license": "MIT",
+  "author": {
+    "name": "ubugeeei"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ubugeeei/vapor-moon.git",
+    "directory": "editors/vscode"
+  },
+  "bugs": {
+    "url": "https://github.com/ubugeeei/vapor-moon/issues"
+  },
+  "homepage": "https://github.com/ubugeeei/vapor-moon#readme",
+  "keywords": [
+    "moonbit",
+    "mbtv",
+    "vapor",
+    "vue",
+    "sfc",
+    "single-file-component"
+  ],
   "engines": {
     "vscode": "^1.90.0"
   },
   "categories": [
-    "Programming Languages"
+    "Programming Languages",
+    "Snippets",
+    "Linters"
   ],
   "activationEvents": [
     "onLanguage:vapor-moon"
   ],
   "main": "./extension.js",
+  "scripts": {
+    "package": "vsce package --no-dependencies",
+    "publish": "vsce publish --no-dependencies"
+  },
   "contributes": {
     "languages": [
       {

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "zed_vapor_moon"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zed_vapor_moon"
-version = "0.1.0"
+# Keep in sync with editors/zed/extension.toml and moon.mod.json.
+version = "0.1.1"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "vapor-moon"
 name = "Vapor Moon"
 description = "Vapor Moon support for .mbtv Single File Components."
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["Ubugeeei <ubugeeei@gmail.com>"]
 repository = "https://github.com/ubugeeei/vapor-moon"

--- a/scripts/smoke_cli.sh
+++ b/scripts/smoke_cli.sh
@@ -39,3 +39,21 @@ moon run src/cmd/vapor_moon -- compile "$ROOT/examples/basic.mbtv" >"$OUT"
 grep -q "=== client ===" "$OUT"
 grep -q "=== server ===" "$OUT"
 grep -q "component=Basic" "$OUT"
+
+# --help / -h / help exit 0 and surface the structured help.
+for flag in --help -h help; do
+  moon run src/cmd/vapor_moon -- "$flag" >"$OUT"
+  grep -q "^USAGE:" "$OUT"
+  grep -q "^COMMANDS:" "$OUT"
+done
+
+# --version / -V exit 0 and print the package version that matches moon.mod.json.
+expected_version="$(grep -m1 '"version"' "$ROOT/moon.mod.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+if [ -z "$expected_version" ]; then
+  echo "could not read version from moon.mod.json"
+  exit 1
+fi
+for flag in --version -V; do
+  moon run src/cmd/vapor_moon -- "$flag" >"$OUT"
+  grep -q "^vapor-moon ${expected_version}$" "$OUT"
+done

--- a/src/cmd/vapor_moon_cli/cli.mbt
+++ b/src/cmd/vapor_moon_cli/cli.mbt
@@ -14,6 +14,21 @@ extern "c" fn watch_sleep_micros(microseconds : UInt64) -> Int = "usleep"
 ///|
 /// Dispatch the small CLI surface used for local compiler and tooling experiments.
 pub fn run(args : Array[String]) -> Unit {
+  if args.length() < 2 {
+    exit_usage()
+    return
+  }
+  match args[1] {
+    "--help" | "-h" | "help" => {
+      print_help()
+      return
+    }
+    "--version" | "-V" => {
+      println("vapor-moon " + @compiler_common.VERSION)
+      return
+    }
+    _ => ()
+  }
   if args.length() < 3 {
     exit_usage()
     return
@@ -542,7 +557,32 @@ fn exit_usage() -> Unit {
 ///|
 /// Print the supported CLI command surface.
 fn print_usage() -> Unit {
-  println(
-    "Usage: moon run src/cmd/vapor_moon -- <compile|watch|analyze|diagnostics|hover|definition|references|complete|format> <file.mbtv|directory> [line] [character] [includeDeclaration]",
-  )
+  println("Usage: vapor-moon <command> <file.mbtv|directory> [args...]")
+  println("       vapor-moon --help | --version")
+  println("Run `vapor-moon --help` for the full command list.")
+}
+
+///|
+/// Print the full structured help, used by `--help`, `-h`, and `help`.
+fn print_help() -> Unit {
+  println("vapor-moon " + @compiler_common.VERSION)
+  println("MoonBit-first Single File Component compiler and tooling.")
+  println("")
+  println("USAGE:")
+  println("  vapor-moon <command> <file.mbtv|directory> [args...]")
+  println("  vapor-moon --help | -h")
+  println("  vapor-moon --version | -V")
+  println("")
+  println("COMMANDS:")
+  println("  compile     <file.mbtv>                            Compile one .mbtv file and print client/server/css snapshot.")
+  println("  watch       <directory>                            Recompile .mbtv files in <directory> on change.")
+  println("  analyze     <file.mbtv>                            Print the analyzed SFC structure.")
+  println("  diagnostics <file.mbtv>                            Print diagnostics for one file.")
+  println("  hover       <file.mbtv> <line> <character>         Print the hover result at a position.")
+  println("  definition  <file.mbtv> <line> <character>         Print the definition at a position.")
+  println("  references  <file.mbtv> <line> <character> [bool]  Print references at a position; final arg toggles includeDeclaration (default true).")
+  println("  complete    <file.mbtv> <line> <character>         Print completion items at a position.")
+  println("  format      <file.mbtv>                            Print the formatted source.")
+  println("")
+  println("Positions are zero-based (LSP semantics).")
 }

--- a/src/cmd/vapor_moon_cli/cli.mbt
+++ b/src/cmd/vapor_moon_cli/cli.mbt
@@ -574,15 +574,33 @@ fn print_help() -> Unit {
   println("  vapor-moon --version | -V")
   println("")
   println("COMMANDS:")
-  println("  compile     <file.mbtv>                            Compile one .mbtv file and print client/server/css snapshot.")
-  println("  watch       <directory>                            Recompile .mbtv files in <directory> on change.")
-  println("  analyze     <file.mbtv>                            Print the analyzed SFC structure.")
-  println("  diagnostics <file.mbtv>                            Print diagnostics for one file.")
-  println("  hover       <file.mbtv> <line> <character>         Print the hover result at a position.")
-  println("  definition  <file.mbtv> <line> <character>         Print the definition at a position.")
-  println("  references  <file.mbtv> <line> <character> [bool]  Print references at a position; final arg toggles includeDeclaration (default true).")
-  println("  complete    <file.mbtv> <line> <character>         Print completion items at a position.")
-  println("  format      <file.mbtv>                            Print the formatted source.")
+  println(
+    "  compile     <file.mbtv>                            Compile one .mbtv file and print client/server/css snapshot.",
+  )
+  println(
+    "  watch       <directory>                            Recompile .mbtv files in <directory> on change.",
+  )
+  println(
+    "  analyze     <file.mbtv>                            Print the analyzed SFC structure.",
+  )
+  println(
+    "  diagnostics <file.mbtv>                            Print diagnostics for one file.",
+  )
+  println(
+    "  hover       <file.mbtv> <line> <character>         Print the hover result at a position.",
+  )
+  println(
+    "  definition  <file.mbtv> <line> <character>         Print the definition at a position.",
+  )
+  println(
+    "  references  <file.mbtv> <line> <character> [bool]  Print references at a position; final arg toggles includeDeclaration (default true).",
+  )
+  println(
+    "  complete    <file.mbtv> <line> <character>         Print completion items at a position.",
+  )
+  println(
+    "  format      <file.mbtv>                            Print the formatted source.",
+  )
   println("")
   println("Positions are zero-based (LSP semantics).")
 }

--- a/src/cmd/vapor_moon_cli/moon.pkg
+++ b/src/cmd/vapor_moon_cli/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "ubugeeei/vapor_moon/src/compiler" @compiler,
+  "ubugeeei/vapor_moon/src/compiler/common" @compiler_common,
   "ubugeeei/vapor_moon/src/compiler/incremental" @incremental,
   "ubugeeei/vapor_moon/src/tooling" @tooling,
   "moonbitlang/core/encoding/utf8" @utf8,

--- a/src/compiler/codegen/attrs_binding.mbt
+++ b/src/compiler/codegen/attrs_binding.mbt
@@ -163,6 +163,25 @@ fn render_client_model_attrs(
   let parts : Array[String] = []
   match element.model {
     Some(model) if not(element.is_component) => {
+      if is_select_multiple_model(element) {
+        // <select multiple v-model="xs">: lower to a runtime helper that
+        // walks <option> children and syncs `selected` from xs, and
+        // collects event.target.selectedOptions on change. We piggyback on
+        // the `__ref`-style Handler attribute so the helper fires once
+        // with the live element. See `bind_select_multiple_model` in
+        // src/runtime/dom/dom.mbt.
+        let setter = render_model_write_expr(
+          model.expression, "__vm_select_values",
+        )
+        parts.push(
+          "(\"__selectMultipleModel\", @dom.on(fn(__vm_select_elem) { @dom.bind_select_multiple_model(__vm_select_elem, fn() { " +
+          model.expression +
+          " }, fn(__vm_select_values) { " +
+          setter +
+          " }) }))",
+        )
+        return parts
+      }
       let checked = infer_model_checked(element)
       let radio = is_radio_model(element)
       let event_name = render_model_event_name(element, model, checked || radio)
@@ -207,6 +226,12 @@ fn render_server_model_attrs(
   let parts : Array[String] = []
   match element.model {
     Some(model) if not(element.is_component) => {
+      // SSR for <select multiple v-model> is intentionally a no-op for
+      // now: the multiple-select behavior (selected options) lives on
+      // the client and is applied on hydration. See bind_select_multiple_model.
+      if is_select_multiple_model(element) {
+        return parts
+      }
       let checked = infer_model_checked(element)
       let radio = is_radio_model(element)
       let attr_name = if checked || radio { "checked" } else { "value" }
@@ -236,6 +261,19 @@ fn render_server_model_attrs(
     _ => ()
   }
   parts
+}
+
+///|
+fn is_select_multiple_model(element : TemplateElement) -> Bool {
+  if element.tag != "select" {
+    return false
+  }
+  for attr in element.attrs {
+    if attr.name == "multiple" {
+      return true
+    }
+  }
+  false
 }
 
 ///|

--- a/src/compiler/codegen/attrs_binding.mbt
+++ b/src/compiler/codegen/attrs_binding.mbt
@@ -132,6 +132,12 @@ fn render_server_component_event_attr(attr : TemplateAttr) -> String {
 }
 
 ///|
+/// Lower a `v-unsafe-html` binding to the client `__innerHTML` attribute.
+///
+/// SECURITY: this is the client-side half of the `v-unsafe-html` escape
+/// hatch. The runtime's `apply_static_attr` writes the value straight onto
+/// `Element.innerHTML` (see `src/runtime/dom/dom.mbt`), with no escaping.
+/// Author responsibility — see README "Security Model" and SECURITY.md.
 fn render_client_html_attr(
   element : TemplateElement,
   static_mode : Bool,

--- a/src/compiler/codegen/attrs_binding.mbt
+++ b/src/compiler/codegen/attrs_binding.mbt
@@ -171,7 +171,8 @@ fn render_client_model_attrs(
         // with the live element. See `bind_select_multiple_model` in
         // src/runtime/dom/dom.mbt.
         let setter = render_model_write_expr(
-          model.expression, "__vm_select_values",
+          model.expression,
+          "__vm_select_values",
         )
         parts.push(
           "(\"__selectMultipleModel\", @dom.on(fn(__vm_select_elem) { @dom.bind_select_multiple_model(__vm_select_elem, fn() { " +

--- a/src/compiler/codegen/elements.mbt
+++ b/src/compiler/codegen/elements.mbt
@@ -31,6 +31,17 @@ fn render_client_element(
 }
 
 ///|
+/// Render a host element on the SSR target.
+///
+/// SECURITY: when `element.html_expr` is `Some(expr)`, the element carries a
+/// `v-unsafe-html` binding. We deliberately lower the expression into
+/// `@luna_core.raw_html` without escaping — this is the documented escape
+/// hatch (see README "Security Model" and SECURITY.md). The directive name
+/// keeps the boundary visible to authors; the compiler's only safety
+/// guarantee is the placement check in
+/// `src/compiler/template/builder_validate.mbt` (void elements, components,
+/// and elements with existing children are rejected). Sanitization is the
+/// caller's responsibility.
 fn render_server_element(
   element : TemplateElement,
   indent : Int,

--- a/src/compiler/common/version.mbt
+++ b/src/compiler/common/version.mbt
@@ -1,0 +1,7 @@
+///|
+/// Single source of truth for the Vapor Moon package version surfaced by the
+/// CLI (`--version`) and the LSP `initialize` response.
+///
+/// Keep this constant in sync with the `version` field of `moon.mod.json` at
+/// the repository root. `scripts/smoke_cli.sh` enforces the invariant in CI.
+pub const VERSION : String = "0.1.1"

--- a/src/compiler/coverage/edge_case_test.mbt
+++ b/src/compiler/coverage/edge_case_test.mbt
@@ -955,16 +955,50 @@ test "rejects unsupported file v-model" {
     #|<template><input type='file' v-model='file' /></template>
   assert_eq(
     compile_error(source, "invalid/v_model_file.mbtv"),
-    "InvalidDirective(\"v-model on <input type=\\\"file\\\"> is not supported yet\")",
+    "InvalidDirective(\"v-model is not supported on <input type=\\\"file\\\">; bind `@change` and read `event.target.files` instead\")",
   )
 }
 
 ///|
-test "rejects unsupported select multiple v-model" {
+test "select multiple v-model lowers to bind_select_multiple_model" {
   let source =
-    #|<template><select multiple v-model='selected'></select></template>
+    #|<script setup>
+    #|let selected : Array[String] = []
+    #|</script>
+    #|<template>
+    #|  <select multiple v-model='selected'>
+    #|    <option value='a'>A</option>
+    #|    <option value='b'>B</option>
+    #|  </select>
+    #|</template>
+  let output = compile(source, filename="examples/v_model_select_multiple.mbtv")
+  let client = output.client_code
+  assert_true(client.contains("__selectMultipleModel"))
+  assert_true(client.contains("@dom.bind_select_multiple_model"))
+  assert_true(client.contains("selected"))
+  // SSR is a no-op for multiple-select v-model — the helper only runs
+  // on the client. Make sure we did not emit a `value` attribute that
+  // would clash with the hydration logic.
+  let server = output.server_code
+  assert_true(not(server.contains("__selectMultipleModel")))
+}
+
+///|
+test "select multiple v-model rejects unsupported .trim modifier" {
+  let source =
+    #|<template><select multiple v-model.trim='selected'></select></template>
   assert_eq(
-    compile_error(source, "invalid/v_model_select_multiple.mbtv"),
-    "InvalidDirective(\"v-model on <select multiple> is not supported yet\")",
+    compile_error(source, "invalid/v_model_select_multiple_trim.mbtv"),
+    "InvalidDirective(\"unsupported v-model modifier `.trim` on <select>\")",
+  )
+}
+
+///|
+test "select multiple v-model rejects unsupported .lazy modifier" {
+  let source =
+    #|<template><select multiple v-model.lazy='selected'></select></template>
+  assert_eq(
+    compile_error(source, "invalid/v_model_select_multiple_lazy.mbtv"),
+    "InvalidDirective(\"unsupported v-model modifier `.lazy` on <select multiple>\")",
   )
 }

--- a/src/compiler/template/builder_validate.mbt
+++ b/src/compiler/template/builder_validate.mbt
@@ -224,8 +224,14 @@ fn validate_native_model_binding(
           )
         }
       Some("file") =>
+        // File inputs intentionally do not support v-model. The DOM
+        // `value` property of a file input is read-only for security
+        // reasons, so two-way binding cannot round-trip through it.
+        // Use a `@change` listener that reads `event.target.files`
+        // (typically into a `signal[FileList?]`) and a `ref` for any
+        // programmatic reset. See README "v-model".
         raise CompilerError::InvalidDirective(
-          "v-model on <input type=\"file\"> is not supported yet",
+          "v-model is not supported on <input type=\"file\">; bind `@change` and read `event.target.files` instead",
         )
       Some("checkbox") =>
         if has_model_modifier_name(model, "trim") {
@@ -237,14 +243,15 @@ fn validate_native_model_binding(
     }
   }
   if tag == "select" {
-    if has_attr(attrs, "multiple") {
-      raise CompilerError::InvalidDirective(
-        "v-model on <select multiple> is not supported yet",
-      )
-    }
+    let multiple = has_attr(attrs, "multiple")
     if has_model_modifier_name(model, "trim") {
       raise CompilerError::InvalidDirective(
         "unsupported v-model modifier `.trim` on <select>",
+      )
+    }
+    if multiple && has_model_modifier_name(model, "lazy") {
+      raise CompilerError::InvalidDirective(
+        "unsupported v-model modifier `.lazy` on <select multiple>",
       )
     }
   }

--- a/src/compiler/template/builder_validate.mbt
+++ b/src/compiler/template/builder_validate.mbt
@@ -1,4 +1,18 @@
 ///|
+/// Final structural checks once an element's children are known.
+///
+/// SECURITY: this is the placement guard for the `v-unsafe-html` escape
+/// hatch. The directive bypasses HTML escaping at the runtime, so the
+/// compiler intentionally narrows the set of elements where it is legal:
+///
+/// - void elements (e.g. `<br>`, `<img>`) — innerHTML has no meaning;
+/// - elements that already declare children — silently swapping them with
+///   raw HTML would surprise the author.
+///
+/// Component tags get a dedicated rejection in `validate_directive_modifiers`
+/// below. Together these checks keep the trust boundary explicit — escape is
+/// always opt-in through `v-unsafe-html`, never an accident. See README
+/// "Security Model" and SECURITY.md.
 fn validate_finalized_element(
   element : TemplateElement,
   children : Array[TemplateNode],

--- a/src/lsp/messages.mbt
+++ b/src/lsp/messages.mbt
@@ -64,15 +64,10 @@ pub fn initialize_payload() -> @js.Any {
             ("triggerCharacters", @js.any([".", ":", "-", "@", "#"])),
           ]),
         ),
-        (
-          "renameProvider",
-          json_object([("prepareProvider", @js.any(true))]),
-        ),
+        ("renameProvider", json_object([("prepareProvider", @js.any(true))])),
         (
           "codeActionProvider",
-          json_object([
-            ("codeActionKinds", @js.any(["quickfix", "refactor"])),
-          ]),
+          json_object([("codeActionKinds", @js.any(["quickfix", "refactor"]))]),
         ),
       ]),
     ),

--- a/src/lsp/messages.mbt
+++ b/src/lsp/messages.mbt
@@ -64,13 +64,23 @@ pub fn initialize_payload() -> @js.Any {
             ("triggerCharacters", @js.any([".", ":", "-", "@", "#"])),
           ]),
         ),
+        (
+          "renameProvider",
+          json_object([("prepareProvider", @js.any(true))]),
+        ),
+        (
+          "codeActionProvider",
+          json_object([
+            ("codeActionKinds", @js.any(["quickfix", "refactor"])),
+          ]),
+        ),
       ]),
     ),
     (
       "serverInfo",
       json_object([
         ("name", @js.any("Vapor Moon LSP")),
-        ("version", @js.any("0.1.0")),
+        ("version", @js.any(@compiler_common.VERSION)),
       ]),
     ),
     ("positionEncoding", @js.any("utf-16")),
@@ -147,6 +157,21 @@ pub fn formatting_payload(edits : Array[@tooling.ToolingTextEdit]) -> @js.Any {
       ]),
     )
   }
+  @js.any(payload)
+}
+
+///|
+/// Phase 1 rename payload: an empty `WorkspaceEdit` keeps the editor in the
+/// rename code path without applying any document changes.
+pub fn empty_workspace_edit() -> @js.Any {
+  json_object([("changes", json_object([]))])
+}
+
+///|
+/// Phase 1 codeAction payload: an empty list signals "no quick fixes here"
+/// without surfacing a method-not-found error.
+pub fn empty_code_action_list() -> @js.Any {
+  let payload : Array[@js.Any] = []
   @js.any(payload)
 }
 

--- a/src/lsp/moon.pkg
+++ b/src/lsp/moon.pkg
@@ -6,6 +6,7 @@ import {
   "mizchi/js/node/stream" @stream,
   "mizchi/js/node/tty" @tty,
   "moonbitlang/core/strconv" @strconv,
+  "ubugeeei/vapor_moon/src/compiler/common" @compiler_common,
   "ubugeeei/vapor_moon/src/tooling" @tooling,
 }
 

--- a/src/lsp/server.mbt
+++ b/src/lsp/server.mbt
@@ -47,6 +47,9 @@ fn dispatch_request(
     "textDocument/references" => handle_references(state, request)
     "textDocument/completion" => handle_completion(state, request)
     "textDocument/formatting" => handle_formatting(state, request)
+    "textDocument/prepareRename" => handle_prepare_rename(request)
+    "textDocument/rename" => handle_rename(request)
+    "textDocument/codeAction" => handle_code_action(request)
     _ => reply_missing_method(request)
   }
 }
@@ -233,6 +236,29 @@ fn handle_formatting(
         request, invalid_params_code, "formatting requires textDocument.uri",
       )
   }
+}
+
+///|
+/// Phase 1 rename support: tell the editor the position is not renameable yet.
+/// Returning `null` is the LSP-blessed way to decline rename without surfacing
+/// an "unsupported method" error.
+fn handle_prepare_rename(request : RequestMessage) -> ServerResult {
+  reply_ok(request, json_null())
+}
+
+///|
+/// Phase 1 rename support: respond with an empty `WorkspaceEdit` so editors
+/// keep rename available in their command palette without producing edits.
+fn handle_rename(request : RequestMessage) -> ServerResult {
+  reply_ok(request, empty_workspace_edit())
+}
+
+///|
+/// Phase 1 codeAction support: advertise the capability and return an empty
+/// list. Real quick-fixes will be wired from the diagnostics layer in a
+/// follow-up issue.
+fn handle_code_action(request : RequestMessage) -> ServerResult {
+  reply_ok(request, empty_code_action_list())
 }
 
 ///|

--- a/src/lsp/server_test.mbt
+++ b/src/lsp/server_test.mbt
@@ -248,7 +248,97 @@ test "initialize advertises hover definition completion references and formattin
     result.messages[0].contains("\"documentFormattingProvider\":true"),
   )
   assert_true(result.messages[0].contains("\"completionProvider\""))
+  assert_true(result.messages[0].contains("\"renameProvider\""))
+  assert_true(result.messages[0].contains("\"prepareProvider\":true"))
+  assert_true(result.messages[0].contains("\"codeActionProvider\""))
+  assert_true(result.messages[0].contains("\"quickfix\""))
   assert_true(result.messages[0].contains("\"positionEncoding\":\"utf-16\""))
+  assert_true(
+    result.messages[0].contains(
+      "\"version\":\"" + @compiler_common.VERSION + "\"",
+    ),
+  )
+}
+
+///|
+test "prepareRename, rename, and codeAction return graceful empty responses" {
+  let state = ServerState::new()
+  ignore(
+    handle_message(
+      state,
+      open_request("file:///Component.mbtv", component_source()),
+    ),
+  )
+  let prepare = handle_message(
+    state,
+    position_request(10, "textDocument/prepareRename", 0, 0),
+  )
+  assert_true(prepare.messages[0].contains("\"result\":null"))
+  let rename = handle_message(
+    state,
+    stringify_json(
+      json_object([
+        ("jsonrpc", @js.any("2.0")),
+        ("id", @js.any(11)),
+        ("method", @js.any("textDocument/rename")),
+        (
+          "params",
+          json_object([
+            (
+              "textDocument",
+              json_object([("uri", @js.any("file:///Component.mbtv"))]),
+            ),
+            (
+              "position",
+              json_object([("line", @js.any(0)), ("character", @js.any(0))]),
+            ),
+            ("newName", @js.any("renamed")),
+          ]),
+        ),
+      ]),
+    ),
+  )
+  assert_true(rename.messages[0].contains("\"changes\":{}"))
+  let code_action = handle_message(
+    state,
+    stringify_json(
+      json_object([
+        ("jsonrpc", @js.any("2.0")),
+        ("id", @js.any(12)),
+        ("method", @js.any("textDocument/codeAction")),
+        (
+          "params",
+          json_object([
+            (
+              "textDocument",
+              json_object([("uri", @js.any("file:///Component.mbtv"))]),
+            ),
+            (
+              "range",
+              json_object([
+                (
+                  "start",
+                  json_object([
+                    ("line", @js.any(0)),
+                    ("character", @js.any(0)),
+                  ]),
+                ),
+                (
+                  "end",
+                  json_object([
+                    ("line", @js.any(0)),
+                    ("character", @js.any(0)),
+                  ]),
+                ),
+              ]),
+            ),
+            ("context", json_object([("diagnostics", @js.any([]))])),
+          ]),
+        ),
+      ]),
+    ),
+  )
+  assert_true(code_action.messages[0].contains("\"result\":[]"))
 }
 
 ///|

--- a/src/lsp/server_test.mbt
+++ b/src/lsp/server_test.mbt
@@ -318,17 +318,11 @@ test "prepareRename, rename, and codeAction return graceful empty responses" {
               json_object([
                 (
                   "start",
-                  json_object([
-                    ("line", @js.any(0)),
-                    ("character", @js.any(0)),
-                  ]),
+                  json_object([("line", @js.any(0)), ("character", @js.any(0))]),
                 ),
                 (
                   "end",
-                  json_object([
-                    ("line", @js.any(0)),
-                    ("character", @js.any(0)),
-                  ]),
+                  json_object([("line", @js.any(0)), ("character", @js.any(0))]),
                 ),
               ]),
             ),

--- a/src/lsp/server_test.mbt
+++ b/src/lsp/server_test.mbt
@@ -327,10 +327,7 @@ test "prepareRename, rename, and codeAction return graceful empty responses" {
                 ),
               ]),
             ),
-            (
-              "context",
-              json_object([("diagnostics", @js.any(no_diagnostics))]),
-            ),
+            ("context", json_object([("diagnostics", @js.any(no_diagnostics))])),
           ]),
         ),
       ]),

--- a/src/lsp/server_test.mbt
+++ b/src/lsp/server_test.mbt
@@ -263,6 +263,7 @@ test "initialize advertises hover definition completion references and formattin
 ///|
 test "prepareRename, rename, and codeAction return graceful empty responses" {
   let state = ServerState::new()
+  let no_diagnostics : Array[@js.Any] = []
   ignore(
     handle_message(
       state,
@@ -326,7 +327,10 @@ test "prepareRename, rename, and codeAction return graceful empty responses" {
                 ),
               ]),
             ),
-            ("context", json_object([("diagnostics", @js.any([]))])),
+            (
+              "context",
+              json_object([("diagnostics", @js.any(no_diagnostics))]),
+            ),
           ]),
         ),
       ]),

--- a/src/runtime/dom/dom.mbt
+++ b/src/runtime/dom/dom.mbt
@@ -238,6 +238,60 @@ pub fn dynStyle(getter : () -> String) -> @luna_dom.AttrValue {
 }
 
 ///|
+extern "js" fn apply_select_multiple_selected(
+  elem : @js.Any,
+  values : Array[String],
+) -> Unit =
+  #| (elem, values) => {
+  #|   const want = new Set(values);
+  #|   const options = elem.options;
+  #|   if (!options) return;
+  #|   for (let i = 0; i < options.length; i++) {
+  #|     options[i].selected = want.has(options[i].value);
+  #|   }
+  #| }
+
+///|
+extern "js" fn install_select_multiple_listener(
+  elem : @js.Any,
+  setter : (Array[String]) -> Unit,
+) -> Unit =
+  #| (elem, setter) => {
+  #|   const onChange = () => {
+  #|     const collected = [];
+  #|     const selected = elem.selectedOptions;
+  #|     if (selected) {
+  #|       for (let i = 0; i < selected.length; i++) {
+  #|         collected.push(selected[i].value);
+  #|       }
+  #|     }
+  #|     setter(collected);
+  #|   };
+  #|   elem.addEventListener("change", onChange);
+  #| }
+
+///|
+/// Lower a `<select multiple v-model="xs">` binding to a runtime loop:
+///
+/// - on every render effect, walk the option children and set their
+///   `selected` property from `getter()`;
+/// - on each `change` event, collect `event.target.selectedOptions` and
+///   feed them back through `setter`.
+///
+/// The compiler emits one call to this function per `<select multiple>`
+/// element through the `__selectMultipleModel` sentinel attribute name.
+pub fn bind_select_multiple_model(
+  elem : @js.Any,
+  getter : () -> Array[String],
+  setter : (Array[String]) -> Unit,
+) -> Unit {
+  install_select_multiple_listener(elem, setter)
+  let _ = @resource.render_effect(fn() {
+    apply_select_multiple_selected(elem, getter())
+  })
+}
+
+///|
 /// Render a component placeholder element for client-side hydration.
 pub fn component_dom(
   name : String,
@@ -482,7 +536,11 @@ pub fn apply_attr(
       })
     }
     @luna_dom.Handler(handler) =>
-      if name == "__ref" {
+      // `__ref` and `__selectMultipleModel` are compiler-internal sentinel
+      // attribute names that piggyback on the Handler variant so the runtime
+      // can invoke a closure once with the live DOM element. They are not
+      // actually written to the DOM.
+      if name == "__ref" || name == "__selectMultipleModel" {
         handler(elem.as_any())
       } else {
         bind_event_handler(elem, name, handler)

--- a/src/runtime/dom/dom.mbt
+++ b/src/runtime/dom/dom.mbt
@@ -500,6 +500,10 @@ fn apply_static_attr(
   if name == "className" || name == "class" {
     elem.setClassName(value)
   } else if name == "__innerHTML" {
+    // SECURITY: `__innerHTML` is the client lowering target for the
+    // compiler's `v-unsafe-html` directive. It writes the value straight onto
+    // `Element.innerHTML` with no sanitization. Callers must pre-escape or
+    // sanitize. See README "Security Model" and SECURITY.md.
     elem.as_any()._set("innerHTML", @js.any(value)) |> ignore
   } else if name == "value" {
     elem.as_any()._set("value", @js.any(value)) |> ignore

--- a/src/tooling/lsp_completion.mbt
+++ b/src/tooling/lsp_completion.mbt
@@ -31,9 +31,12 @@ fn directive_completion_items(prefix : String) -> Array[ToolingCompletionItem] {
     ("v-else", "fallback branch (requires preceding v-if or v-else-if)"),
     ("v-for", "list rendering"),
     ("v-show", "toggle visibility via CSS display"),
-    ("v-unsafe-html", "render unsafe raw HTML content"),
+    ("v-unsafe-html", "render unsafe raw HTML content (no sanitization)"),
     (
-      "v-model", "two-way binding on input/textarea/select and component props; file input/select multiple unsupported",
+      "v-model", "two-way binding (supported: text/checkbox/radio input, textarea, select, component modelValue; unsupported: file input #65, select multiple #64, .lazy/.number/.trim modifiers)",
+    ),
+    (
+      "v-model:prop", "two-way binding to a named component prop (lowers to :prop + @update:prop; no modifiers yet)",
     ),
     ("v-once", "render once (skip reactivity)"),
     ("v-match", "pattern matching on an expression"),

--- a/src/tooling/lsp_completion.mbt
+++ b/src/tooling/lsp_completion.mbt
@@ -33,7 +33,7 @@ fn directive_completion_items(prefix : String) -> Array[ToolingCompletionItem] {
     ("v-show", "toggle visibility via CSS display"),
     ("v-unsafe-html", "render unsafe raw HTML content (no sanitization)"),
     (
-      "v-model", "two-way binding (supported: text/checkbox/radio input, textarea, select, component modelValue; unsupported: file input #65, select multiple #64, .lazy/.number/.trim modifiers)",
+      "v-model", "two-way binding (supported: text/checkbox/radio input, textarea, select, select multiple via Array[String], component modelValue; unsupported: file input (use @change + event.target.files), .number/.trim modifiers outside text inputs)",
     ),
     (
       "v-model:prop", "two-way binding to a named component prop (lowers to :prop + @update:prop; no modifiers yet)",

--- a/src/tooling/tooling_lsp_test.mbt
+++ b/src/tooling/tooling_lsp_test.mbt
@@ -232,7 +232,7 @@ test "snapshot lsp completion" {
   inspect(
     complete_at(source, 10, 28, filename="examples/complete.mbtv").to_string(),
     content=(
-      #|[{label: v-if, kind: directive, detail: conditional rendering, insert_text: v-if}, {label: v-else-if, kind: directive, detail: conditional branch (requires preceding v-if), insert_text: v-else-if}, {label: v-else, kind: directive, detail: fallback branch (requires preceding v-if or v-else-if), insert_text: v-else}, {label: v-for, kind: directive, detail: list rendering, insert_text: v-for}, {label: v-show, kind: directive, detail: toggle visibility via CSS display, insert_text: v-show}, {label: v-unsafe-html, kind: directive, detail: render unsafe raw HTML content (no sanitization), insert_text: v-unsafe-html}, {label: v-model, kind: directive, detail: two-way binding (supported: text/checkbox/radio input, textarea, select, component modelValue; unsupported: file input #65, select multiple #64, .lazy/.number/.trim modifiers), insert_text: v-model}, {label: v-model:prop, kind: directive, detail: two-way binding to a named component prop (lowers to :prop + @update:prop; no modifiers yet), insert_text: v-model:prop}, {label: v-once, kind: directive, detail: render once (skip reactivity), insert_text: v-once}, {label: v-match, kind: directive, detail: pattern matching on an expression, insert_text: v-match}, {label: v-case, kind: directive, detail: match branch pattern (inside v-match), insert_text: v-case}, {label: v-default, kind: directive, detail: default match branch (inside v-match), insert_text: v-default}]
+      #|[{label: v-if, kind: directive, detail: conditional rendering, insert_text: v-if}, {label: v-else-if, kind: directive, detail: conditional branch (requires preceding v-if), insert_text: v-else-if}, {label: v-else, kind: directive, detail: fallback branch (requires preceding v-if or v-else-if), insert_text: v-else}, {label: v-for, kind: directive, detail: list rendering, insert_text: v-for}, {label: v-show, kind: directive, detail: toggle visibility via CSS display, insert_text: v-show}, {label: v-unsafe-html, kind: directive, detail: render unsafe raw HTML content (no sanitization), insert_text: v-unsafe-html}, {label: v-model, kind: directive, detail: two-way binding (supported: text/checkbox/radio input, textarea, select, select multiple via Array[String], component modelValue; unsupported: file input (use @change + event.target.files), .number/.trim modifiers outside text inputs), insert_text: v-model}, {label: v-model:prop, kind: directive, detail: two-way binding to a named component prop (lowers to :prop + @update:prop; no modifiers yet), insert_text: v-model:prop}, {label: v-once, kind: directive, detail: render once (skip reactivity), insert_text: v-once}, {label: v-match, kind: directive, detail: pattern matching on an expression, insert_text: v-match}, {label: v-case, kind: directive, detail: match branch pattern (inside v-match), insert_text: v-case}, {label: v-default, kind: directive, detail: default match branch (inside v-match), insert_text: v-default}]
     ),
   )
 }
@@ -257,9 +257,8 @@ test "v-model completion detail mentions partial-support boundaries" {
       saw_v_model = true
       assert_true(item.detail.contains("supported"))
       assert_true(item.detail.contains("unsupported"))
-      assert_true(item.detail.contains("file input #65"))
-      assert_true(item.detail.contains("select multiple #64"))
-      assert_true(item.detail.contains(".lazy"))
+      assert_true(item.detail.contains("select multiple via Array[String]"))
+      assert_true(item.detail.contains("file input"))
     }
     if item.label == "v-model:prop" {
       saw_v_model_prop = true

--- a/src/tooling/tooling_lsp_test.mbt
+++ b/src/tooling/tooling_lsp_test.mbt
@@ -245,7 +245,10 @@ test "v-model completion detail mentions partial-support boundaries" {
     #|</template>
   let (line, character) = line_character_at(source, "v- />")
   let completions = complete_at(
-    source, line, character + 2, filename="examples/complete_v_model.mbtv",
+    source,
+    line,
+    character + 2,
+    filename="examples/complete_v_model.mbtv",
   )
   let mut saw_v_model = false
   let mut saw_v_model_prop = false

--- a/src/tooling/tooling_lsp_test.mbt
+++ b/src/tooling/tooling_lsp_test.mbt
@@ -232,9 +232,40 @@ test "snapshot lsp completion" {
   inspect(
     complete_at(source, 10, 28, filename="examples/complete.mbtv").to_string(),
     content=(
-      #|[{label: v-if, kind: directive, detail: conditional rendering, insert_text: v-if}, {label: v-else-if, kind: directive, detail: conditional branch (requires preceding v-if), insert_text: v-else-if}, {label: v-else, kind: directive, detail: fallback branch (requires preceding v-if or v-else-if), insert_text: v-else}, {label: v-for, kind: directive, detail: list rendering, insert_text: v-for}, {label: v-show, kind: directive, detail: toggle visibility via CSS display, insert_text: v-show}, {label: v-unsafe-html, kind: directive, detail: render unsafe raw HTML content, insert_text: v-unsafe-html}, {label: v-model, kind: directive, detail: two-way binding on input/textarea/select and component props; file input/select multiple unsupported, insert_text: v-model}, {label: v-once, kind: directive, detail: render once (skip reactivity), insert_text: v-once}, {label: v-match, kind: directive, detail: pattern matching on an expression, insert_text: v-match}, {label: v-case, kind: directive, detail: match branch pattern (inside v-match), insert_text: v-case}, {label: v-default, kind: directive, detail: default match branch (inside v-match), insert_text: v-default}]
+      #|[{label: v-if, kind: directive, detail: conditional rendering, insert_text: v-if}, {label: v-else-if, kind: directive, detail: conditional branch (requires preceding v-if), insert_text: v-else-if}, {label: v-else, kind: directive, detail: fallback branch (requires preceding v-if or v-else-if), insert_text: v-else}, {label: v-for, kind: directive, detail: list rendering, insert_text: v-for}, {label: v-show, kind: directive, detail: toggle visibility via CSS display, insert_text: v-show}, {label: v-unsafe-html, kind: directive, detail: render unsafe raw HTML content (no sanitization), insert_text: v-unsafe-html}, {label: v-model, kind: directive, detail: two-way binding (supported: text/checkbox/radio input, textarea, select, component modelValue; unsupported: file input #65, select multiple #64, .lazy/.number/.trim modifiers), insert_text: v-model}, {label: v-model:prop, kind: directive, detail: two-way binding to a named component prop (lowers to :prop + @update:prop; no modifiers yet), insert_text: v-model:prop}, {label: v-once, kind: directive, detail: render once (skip reactivity), insert_text: v-once}, {label: v-match, kind: directive, detail: pattern matching on an expression, insert_text: v-match}, {label: v-case, kind: directive, detail: match branch pattern (inside v-match), insert_text: v-case}, {label: v-default, kind: directive, detail: default match branch (inside v-match), insert_text: v-default}]
     ),
   )
+}
+
+///|
+test "v-model completion detail mentions partial-support boundaries" {
+  let source =
+    #|<template>
+    #|  <input v- />
+    #|</template>
+  let (line, character) = line_character_at(source, "v- />")
+  let completions = complete_at(
+    source, line, character + 2, filename="examples/complete_v_model.mbtv",
+  )
+  let mut saw_v_model = false
+  let mut saw_v_model_prop = false
+  for item in completions {
+    if item.label == "v-model" {
+      saw_v_model = true
+      assert_true(item.detail.contains("supported"))
+      assert_true(item.detail.contains("unsupported"))
+      assert_true(item.detail.contains("file input #65"))
+      assert_true(item.detail.contains("select multiple #64"))
+      assert_true(item.detail.contains(".lazy"))
+    }
+    if item.label == "v-model:prop" {
+      saw_v_model_prop = true
+      assert_true(item.detail.contains("named component prop"))
+      assert_true(item.detail.contains("@update:prop"))
+    }
+  }
+  assert_true(saw_v_model)
+  assert_true(saw_v_model_prop)
 }
 
 ///|


### PR DESCRIPTION
## Summary

Implements every issue filed in this triage round (#80–#88). One PR
because the changes are interlinked (shared `VERSION` constant flows
into CLI, LSP, and CHANGELOG; CI matrix + VS Code Marketplace publish
share the same release workflow).

### CLI (#80) and LSP version drift (#85)
- `vapor-moon --help` / `-h` / `help` and `vapor-moon --version` / `-V` flags.
- New `src/compiler/common/version.mbt` is the single source of truth.
  The LSP `initialize` payload now reads it (was hard-coded `0.1.0`).
- `scripts/smoke_cli.sh` covers both flags and asserts the version matches
  `moon.mod.json`.

### LSP rename / codeAction Phase 1 (#86)
- `initialize` advertises `renameProvider` (with `prepareProvider`) and
  `codeActionProvider` (`quickfix` + `refactor`).
- `textDocument/prepareRename` → `null`; `textDocument/rename` → empty
  `WorkspaceEdit`; `textDocument/codeAction` → `[]`. Editors stop
  reporting "method not found".
- New test in `src/lsp/server_test.mbt` covers the capability set and
  empty payload shape.

### VS Code extension (#84) + Marketplace publish (#87)
- `editors/vscode/package.json` gains `repository`, `bugs`, `homepage`,
  `keywords`, `author`, `categories`, `package`/`publish` scripts.
- Extension version bumped to `0.1.1` to track `moon.mod.json`; CI fails
  if they drift.
- `editor-integrations` job now runs `vsce package` and validates the
  required marketplace fields.
- New `vscode-extension` job in `release.yaml`: packages the `.vsix`,
  uploads it as a workflow artifact, attaches to the GitHub Release,
  and (when `VSCE_PAT` is set) publishes to the Marketplace.

### CI cross-platform matrix (#83)
- `check-native` is now a matrix over `ubuntu-latest` and `macos-latest`
  with per-leg SHA-256 inputs. macOS leaves its checksums empty for now;
  the SHA pinning is the remaining work tracked in #83.

### Docs and community health (#81, #82, #88)
- `CHANGELOG.md` (Keep a Changelog) with `[Unreleased]`, `[0.1.1]`,
  `[0.1.0]` reconstructed from closed issues + git history.
- `CONTRIBUTING.md` (prereqs, local commands, conventional commits, PR
  checklist, release procedure).
- `SECURITY.md` (supported versions, private reporting, in/out-of-scope
  surfaces).
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,documentation,config.yml}`
  and `.github/pull_request_template.md`.
- README "Security model" section documenting escape-by-default vs.
  `v-unsafe-html` opt-out plus links to CONTRIBUTING / SECURITY /
  CHANGELOG.
- `docs/ISSUES.md` rewritten to point at the new issue set.

## Test plan

- [x] `git push` (branch builds run in CI).
- [ ] Wait for CI: `check-native` (ubuntu + macos), `check-js`,
      `editor-integrations` (now with `vsce package`), `e2e`.
- [ ] Verify `scripts/smoke_cli.sh` exercises the new `--help`/`-h`/
      `help` and `--version`/`-V` flags.
- [ ] On a tag push (`v0.1.x`), verify `release.yaml` produces a
      `vapor-moon.vsix` artifact and (with `VSCE_PAT` configured)
      publishes to the Marketplace.

## Closes

Closes #80, #81, #82, #84, #85, #87, #88.
Phase-1 partial for #83 (macOS leg added; SHA pinning remains).
Phase-1 partial for #86 (capability + stub responses shipped;
Phase 2 — real rename via references query and codeAction wired
from diagnostics — tracked in the same issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)