### PR TITLE
chore(moonbit): replace not(...) calls with !(...) (#53 part 1)

### DIFF
--- a/src/cmd/vapor_moon_cli/cli.mbt
+++ b/src/cmd/vapor_moon_cli/cli.mbt
@@ -103,7 +103,7 @@ fn read_text_or_exit(path : String) -> String {
 fn watch_directory(root : String) -> Unit {
   let root_dir : @path.Path = root
   let resolved_root = root_dir.resolve().to_string()
-  if not(@fs.path_exists(resolved_root)) {
+  if !(@fs.path_exists(resolved_root)) {
     println("watch root does not exist: " + resolved_root)
     @sys.exit(1)
     return
@@ -115,7 +115,7 @@ fn watch_directory(root : String) -> Unit {
       return
     }
   }
-  if not(is_dir) {
+  if !(is_dir) {
     println("watch root is not a directory: " + resolved_root)
     @sys.exit(1)
     return
@@ -319,7 +319,7 @@ pub fn generated_output_paths(source_path : String) -> GeneratedOutputPaths {
 ///|
 /// Strip the trailing `.mbtv` extension used by Vapor Moon source files.
 fn strip_watch_source_extension(path : String) -> String {
-  if not(path.has_suffix(".mbtv")) {
+  if !(path.has_suffix(".mbtv")) {
     return path
   }
   String::unsafe_substring(path, start=0, end=path.length() - 5)
@@ -357,7 +357,7 @@ pub fn remove_generated_outputs(source_path : String) -> Unit {
 ///|
 /// Best-effort file removal helper used during watch cleanup.
 fn remove_file_if_exists(path : String) -> Unit {
-  if not(@fs.path_exists(path)) {
+  if !(@fs.path_exists(path)) {
     return
   }
   ignore(@fs.remove_file(path) catch { _ => () })

--- a/src/cmd/vapor_moon_cli/cli.mbt
+++ b/src/cmd/vapor_moon_cli/cli.mbt
@@ -103,7 +103,7 @@ fn read_text_or_exit(path : String) -> String {
 fn watch_directory(root : String) -> Unit {
   let root_dir : @path.Path = root
   let resolved_root = root_dir.resolve().to_string()
-  if !(@fs.path_exists(resolved_root)) {
+  if !@fs.path_exists(resolved_root) {
     println("watch root does not exist: " + resolved_root)
     @sys.exit(1)
     return
@@ -115,7 +115,7 @@ fn watch_directory(root : String) -> Unit {
       return
     }
   }
-  if !(is_dir) {
+  if !is_dir {
     println("watch root is not a directory: " + resolved_root)
     @sys.exit(1)
     return
@@ -319,7 +319,7 @@ pub fn generated_output_paths(source_path : String) -> GeneratedOutputPaths {
 ///|
 /// Strip the trailing `.mbtv` extension used by Vapor Moon source files.
 fn strip_watch_source_extension(path : String) -> String {
-  if !(path.has_suffix(".mbtv")) {
+  if !path.has_suffix(".mbtv") {
     return path
   }
   String::unsafe_substring(path, start=0, end=path.length() - 5)
@@ -357,7 +357,7 @@ pub fn remove_generated_outputs(source_path : String) -> Unit {
 ///|
 /// Best-effort file removal helper used during watch cleanup.
 fn remove_file_if_exists(path : String) -> Unit {
-  if !(@fs.path_exists(path)) {
+  if !@fs.path_exists(path) {
     return
   }
   ignore(@fs.remove_file(path) catch { _ => () })

--- a/src/cmd/vapor_moon_cli/cli_test.mbt
+++ b/src/cmd/vapor_moon_cli/cli_test.mbt
@@ -19,7 +19,7 @@ fn cleanup_command_test_dir(root : String) -> Unit {
 
 ///|
 fn cleanup_command_test_tree(path : String) -> Unit {
-  if !(@fs.path_exists(path)) {
+  if !@fs.path_exists(path) {
     return
   }
   let is_dir = @fs.is_dir(path) catch { _ => false }

--- a/src/cmd/vapor_moon_cli/cli_test.mbt
+++ b/src/cmd/vapor_moon_cli/cli_test.mbt
@@ -19,7 +19,7 @@ fn cleanup_command_test_dir(root : String) -> Unit {
 
 ///|
 fn cleanup_command_test_tree(path : String) -> Unit {
-  if not(@fs.path_exists(path)) {
+  if !(@fs.path_exists(path)) {
     return
   }
   let is_dir = @fs.is_dir(path) catch { _ => false }

--- a/src/compiler/codegen/attrs_binding.mbt
+++ b/src/compiler/codegen/attrs_binding.mbt
@@ -156,7 +156,7 @@ fn render_client_model_attrs(
 ) -> Array[String] {
   let parts : Array[String] = []
   match element.model {
-    Some(model) if !(element.is_component) => {
+    Some(model) if !element.is_component => {
       let checked = infer_model_checked(element)
       let radio = is_radio_model(element)
       let event_name = render_model_event_name(element, model, checked || radio)
@@ -200,7 +200,7 @@ fn render_server_model_attrs(
 ) -> Array[String] {
   let parts : Array[String] = []
   match element.model {
-    Some(model) if !(element.is_component) => {
+    Some(model) if !element.is_component => {
       let checked = infer_model_checked(element)
       let radio = is_radio_model(element)
       let attr_name = if checked || radio { "checked" } else { "value" }
@@ -302,7 +302,7 @@ fn render_model_read_expr(model : TemplateModel, checked : Bool) -> String {
   } else {
     "_event._get(\"target\")._get(\"value\").cast()"
   }
-  if !(checked) && has_model_modifier(model, "trim") {
+  if !checked && has_model_modifier(model, "trim") {
     value_expr = "(" + value_expr + ").trim().to_string()"
   }
   value_expr
@@ -333,7 +333,7 @@ fn signal_getter_receiver(target : String) -> String? {
     wrapped,
     name="__vm_model_target__.mbt",
   )
-  if !(reports.is_empty()) {
+  if !reports.is_empty() {
     return None
   }
   for impl_ in impls {
@@ -371,7 +371,7 @@ fn getter_receiver_from_apply_model(
   args : @list.List[@mbt_syntax.Argument],
   source : String,
 ) -> String? {
-  if !(argument_list_is_empty_model(args)) {
+  if !argument_list_is_empty_model(args) {
     return None
   }
   let func = unwrap_group_expr_model(func)

--- a/src/compiler/codegen/attrs_binding.mbt
+++ b/src/compiler/codegen/attrs_binding.mbt
@@ -156,7 +156,7 @@ fn render_client_model_attrs(
 ) -> Array[String] {
   let parts : Array[String] = []
   match element.model {
-    Some(model) if not(element.is_component) => {
+    Some(model) if !(element.is_component) => {
       let checked = infer_model_checked(element)
       let radio = is_radio_model(element)
       let event_name = render_model_event_name(element, model, checked || radio)
@@ -200,7 +200,7 @@ fn render_server_model_attrs(
 ) -> Array[String] {
   let parts : Array[String] = []
   match element.model {
-    Some(model) if not(element.is_component) => {
+    Some(model) if !(element.is_component) => {
       let checked = infer_model_checked(element)
       let radio = is_radio_model(element)
       let attr_name = if checked || radio { "checked" } else { "value" }
@@ -302,7 +302,7 @@ fn render_model_read_expr(model : TemplateModel, checked : Bool) -> String {
   } else {
     "_event._get(\"target\")._get(\"value\").cast()"
   }
-  if not(checked) && has_model_modifier(model, "trim") {
+  if !(checked) && has_model_modifier(model, "trim") {
     value_expr = "(" + value_expr + ").trim().to_string()"
   }
   value_expr
@@ -333,7 +333,7 @@ fn signal_getter_receiver(target : String) -> String? {
     wrapped,
     name="__vm_model_target__.mbt",
   )
-  if not(reports.is_empty()) {
+  if !(reports.is_empty()) {
     return None
   }
   for impl_ in impls {
@@ -371,7 +371,7 @@ fn getter_receiver_from_apply_model(
   args : @list.List[@mbt_syntax.Argument],
   source : String,
 ) -> String? {
-  if not(argument_list_is_empty_model(args)) {
+  if !(argument_list_is_empty_model(args)) {
     return None
   }
   let func = unwrap_group_expr_model(func)

--- a/src/compiler/codegen/attrs_core.mbt
+++ b/src/compiler/codegen/attrs_core.mbt
@@ -6,7 +6,7 @@ fn collect_client_attr_entries(
 ) -> Array[String] {
   let parts : Array[String] = []
   for attr in element.attrs {
-    if attr.name != "style" && not(is_class_attr_name(attr.name)) {
+    if attr.name != "style" && !(is_class_attr_name(attr.name)) {
       parts.push(render_client_attr(attr, static_mode))
     }
   }
@@ -33,7 +33,7 @@ fn render_server_attrs(
 ) -> String {
   let parts : Array[String] = []
   for attr in element.attrs {
-    if attr.name != "style" && not(is_class_attr_name(attr.name)) {
+    if attr.name != "style" && !(is_class_attr_name(attr.name)) {
       match attr.kind {
         Event => ()
         _ => parts.push(render_server_attr(attr, static_mode))

--- a/src/compiler/codegen/attrs_core.mbt
+++ b/src/compiler/codegen/attrs_core.mbt
@@ -6,7 +6,7 @@ fn collect_client_attr_entries(
 ) -> Array[String] {
   let parts : Array[String] = []
   for attr in element.attrs {
-    if attr.name != "style" && !(is_class_attr_name(attr.name)) {
+    if attr.name != "style" && !is_class_attr_name(attr.name) {
       parts.push(render_client_attr(attr, static_mode))
     }
   }
@@ -33,7 +33,7 @@ fn render_server_attrs(
 ) -> String {
   let parts : Array[String] = []
   for attr in element.attrs {
-    if attr.name != "style" && !(is_class_attr_name(attr.name)) {
+    if attr.name != "style" && !is_class_attr_name(attr.name) {
       match attr.kind {
         Event => ()
         _ => parts.push(render_server_attr(attr, static_mode))

--- a/src/compiler/codegen/attrs_style.mbt
+++ b/src/compiler/codegen/attrs_style.mbt
@@ -51,12 +51,12 @@ fn render_style_attr(
   client : Bool,
 ) -> String? {
   let style_attrs = find_style_attrs(element.attrs)
-  if not(style_attrs.is_empty()) {
+  if !(style_attrs.is_empty()) {
     let (base_expr, base_dynamic) = render_merged_attr_expr(
       style_attrs, static_mode, true,
     )
     let dynamic = base_dynamic ||
-      (element.show_expr is Some(_) && not(static_mode))
+      (element.show_expr is Some(_) && !(static_mode))
     let final_expr = match element.show_expr {
       Some(expr) => "@hlp.show_style(" + expr + ", " + base_expr + ")"
       None => base_expr
@@ -68,7 +68,7 @@ fn render_style_attr(
         Some(
           render_style_value(
             "@hlp.show_style(" + expr + ", \"\")",
-            not(static_mode),
+            !(static_mode),
             client,
           ),
         )
@@ -113,7 +113,7 @@ fn render_attr_expr(
 ) -> (String, Bool) {
   match attr.kind {
     Static => (quote(attr.value), false)
-    Dynamic => (attr.value + ".to_string()", not(static_mode))
+    Dynamic => (attr.value + ".to_string()", !(static_mode))
     Boolean => (if style_mode { "\"\"" } else { "\"\"" }, false)
     Event => ("\"\"", false)
   }

--- a/src/compiler/codegen/attrs_style.mbt
+++ b/src/compiler/codegen/attrs_style.mbt
@@ -51,12 +51,11 @@ fn render_style_attr(
   client : Bool,
 ) -> String? {
   let style_attrs = find_style_attrs(element.attrs)
-  if !(style_attrs.is_empty()) {
+  if !style_attrs.is_empty() {
     let (base_expr, base_dynamic) = render_merged_attr_expr(
       style_attrs, static_mode, true,
     )
-    let dynamic = base_dynamic ||
-      (element.show_expr is Some(_) && !(static_mode))
+    let dynamic = base_dynamic || (element.show_expr is Some(_) && !static_mode)
     let final_expr = match element.show_expr {
       Some(expr) => "@hlp.show_style(" + expr + ", " + base_expr + ")"
       None => base_expr
@@ -68,7 +67,7 @@ fn render_style_attr(
         Some(
           render_style_value(
             "@hlp.show_style(" + expr + ", \"\")",
-            !(static_mode),
+            !static_mode,
             client,
           ),
         )
@@ -113,7 +112,7 @@ fn render_attr_expr(
 ) -> (String, Bool) {
   match attr.kind {
     Static => (quote(attr.value), false)
-    Dynamic => (attr.value + ".to_string()", !(static_mode))
+    Dynamic => (attr.value + ".to_string()", !static_mode)
     Boolean => (if style_mode { "\"\"" } else { "\"\"" }, false)
     Event => ("\"\"", false)
   }

--- a/src/compiler/codegen/contracts_surface.mbt
+++ b/src/compiler/codegen/contracts_surface.mbt
@@ -129,17 +129,17 @@ fn render_component_forward_args(doc : SfcDocument) -> String {
 
 ///|
 fn has_props_contract(doc : SfcDocument) -> Bool {
-  doc.props_binding is Some(_) || not(doc.props.is_empty())
+  doc.props_binding is Some(_) || !(doc.props.is_empty())
 }
 
 ///|
 fn has_emits_contract(doc : SfcDocument) -> Bool {
-  doc.emits_binding is Some(_) || not(doc.emits.is_empty())
+  doc.emits_binding is Some(_) || !(doc.emits.is_empty())
 }
 
 ///|
 fn has_slots_contract(doc : SfcDocument) -> Bool {
-  doc.slots_binding is Some(_) || not(doc.slots.is_empty())
+  doc.slots_binding is Some(_) || !(doc.slots.is_empty())
 }
 
 ///|
@@ -197,7 +197,7 @@ fn default_slots_name(client : Bool) -> String {
 
 ///|
 fn has_prop_defaults(doc : SfcDocument) -> Bool {
-  not(doc.prop_defaults.is_empty())
+  !(doc.prop_defaults.is_empty())
 }
 
 ///|

--- a/src/compiler/codegen/contracts_surface.mbt
+++ b/src/compiler/codegen/contracts_surface.mbt
@@ -129,17 +129,17 @@ fn render_component_forward_args(doc : SfcDocument) -> String {
 
 ///|
 fn has_props_contract(doc : SfcDocument) -> Bool {
-  doc.props_binding is Some(_) || !(doc.props.is_empty())
+  doc.props_binding is Some(_) || !doc.props.is_empty()
 }
 
 ///|
 fn has_emits_contract(doc : SfcDocument) -> Bool {
-  doc.emits_binding is Some(_) || !(doc.emits.is_empty())
+  doc.emits_binding is Some(_) || !doc.emits.is_empty()
 }
 
 ///|
 fn has_slots_contract(doc : SfcDocument) -> Bool {
-  doc.slots_binding is Some(_) || !(doc.slots.is_empty())
+  doc.slots_binding is Some(_) || !doc.slots.is_empty()
 }
 
 ///|
@@ -197,7 +197,7 @@ fn default_slots_name(client : Bool) -> String {
 
 ///|
 fn has_prop_defaults(doc : SfcDocument) -> Bool {
-  !(doc.prop_defaults.is_empty())
+  !doc.prop_defaults.is_empty()
 }
 
 ///|

--- a/src/compiler/codegen/elements.mbt
+++ b/src/compiler/codegen/elements.mbt
@@ -13,7 +13,7 @@ fn render_client_element(
   for attr in collect_client_attr_entries(element, scope_id, static_mode) {
     statements.push("@dom.setAttr(" + node_name + ", " + attr + ")")
   }
-  if element.html_expr is None && !(element.children.is_empty()) {
+  if element.html_expr is None && !element.children.is_empty() {
     for
       statement in render_client_append_statements(
         node_name + ".as_node()",
@@ -386,7 +386,7 @@ fn collect_node_islands(node : TemplateNode, result : Array[String]) -> Unit {
     Element(element) => {
       match element.island_mode {
         Load | Idle | Visible | Media(_) | Only | ServerDefer =>
-          if !(local_string_array_contains(result, element.tag)) {
+          if !local_string_array_contains(result, element.tag) {
             result.push(element.tag)
           }
         None => ()
@@ -443,7 +443,7 @@ fn group_children_by_slot(children : Array[TemplateNode]) -> Array[SlotGroup] {
                 break
               }
             }
-            if !(found) {
+            if !found {
               let nodes : Array[TemplateNode] = []
               for inner in element.children {
                 nodes.push(inner)
@@ -456,7 +456,7 @@ fn group_children_by_slot(children : Array[TemplateNode]) -> Array[SlotGroup] {
       _ => default_nodes.push(child)
     }
   }
-  if !(default_nodes.is_empty()) {
+  if !default_nodes.is_empty() {
     let mut has_default = false
     for group in groups {
       if group.name == "default" {
@@ -467,7 +467,7 @@ fn group_children_by_slot(children : Array[TemplateNode]) -> Array[SlotGroup] {
         break
       }
     }
-    if !(has_default) {
+    if !has_default {
       groups.push({ name: "default", nodes: default_nodes })
     }
   }

--- a/src/compiler/codegen/elements.mbt
+++ b/src/compiler/codegen/elements.mbt
@@ -13,7 +13,7 @@ fn render_client_element(
   for attr in collect_client_attr_entries(element, scope_id, static_mode) {
     statements.push("@dom.setAttr(" + node_name + ", " + attr + ")")
   }
-  if element.html_expr is None && not(element.children.is_empty()) {
+  if element.html_expr is None && !(element.children.is_empty()) {
     for
       statement in render_client_append_statements(
         node_name + ".as_node()",
@@ -386,7 +386,7 @@ fn collect_node_islands(node : TemplateNode, result : Array[String]) -> Unit {
     Element(element) => {
       match element.island_mode {
         Load | Idle | Visible | Media(_) | Only | ServerDefer =>
-          if not(local_string_array_contains(result, element.tag)) {
+          if !(local_string_array_contains(result, element.tag)) {
             result.push(element.tag)
           }
         None => ()
@@ -443,7 +443,7 @@ fn group_children_by_slot(children : Array[TemplateNode]) -> Array[SlotGroup] {
                 break
               }
             }
-            if not(found) {
+            if !(found) {
               let nodes : Array[TemplateNode] = []
               for inner in element.children {
                 nodes.push(inner)
@@ -456,7 +456,7 @@ fn group_children_by_slot(children : Array[TemplateNode]) -> Array[SlotGroup] {
       _ => default_nodes.push(child)
     }
   }
-  if not(default_nodes.is_empty()) {
+  if !(default_nodes.is_empty()) {
     let mut has_default = false
     for group in groups {
       if group.name == "default" {
@@ -467,7 +467,7 @@ fn group_children_by_slot(children : Array[TemplateNode]) -> Array[SlotGroup] {
         break
       }
     }
-    if not(has_default) {
+    if !(has_default) {
       groups.push({ name: "default", nodes: default_nodes })
     }
   }

--- a/src/compiler/codegen/module.mbt
+++ b/src/compiler/codegen/module.mbt
@@ -23,7 +23,7 @@ pub fn emit_client_module(
   sb.write_string(emit_component_contracts(doc, component_name, true))
   sb.write_string(render_component_signature(doc, component_name, true))
   if doc.script_setup_transformed is Some(script_setup) &&
-    !(script_setup.trim().is_empty()) {
+    !script_setup.trim().is_empty() {
     sb.write_string(indent_block(script_setup.trim().to_string(), 2))
     sb.write_string("\n")
   }
@@ -70,7 +70,7 @@ pub fn emit_server_module(
   sb.write_string(emit_component_contracts(doc, component_name, false))
   sb.write_string(render_component_signature(doc, component_name, false))
   if doc.script_setup_transformed is Some(script_setup) &&
-    !(script_setup.trim().is_empty()) {
+    !script_setup.trim().is_empty() {
     sb.write_string(indent_block(script_setup.trim().to_string(), 2))
     sb.write_string("\n")
   }
@@ -98,12 +98,12 @@ fn emit_import_block(
 ) -> String {
   let merged : Array[String] = []
   for entry in base_entries {
-    if !(string_array_contains(merged, entry)) {
+    if !string_array_contains(merged, entry) {
       merged.push(entry)
     }
   }
   for entry in extra_entries {
-    if !(string_array_contains(merged, entry)) {
+    if !string_array_contains(merged, entry) {
       merged.push(entry)
     }
   }
@@ -120,7 +120,7 @@ fn emit_import_block(
 
 ///|
 fn emit_extern_script(sb : StringBuilder, doc : SfcDocument) -> Unit {
-  if doc.script_transformed is Some(script) && !(script.trim().is_empty()) {
+  if doc.script_transformed is Some(script) && !script.trim().is_empty() {
     sb.write_string(script.trim().to_string())
     sb.write_string("\n\n")
   }
@@ -133,12 +133,12 @@ fn merge_import_entries(
 ) -> Array[String] {
   let merged : Array[String] = []
   for entry in first {
-    if !(string_array_contains(merged, entry)) {
+    if !string_array_contains(merged, entry) {
       merged.push(entry)
     }
   }
   for entry in second {
-    if !(string_array_contains(merged, entry)) {
+    if !string_array_contains(merged, entry) {
       merged.push(entry)
     }
   }

--- a/src/compiler/codegen/module.mbt
+++ b/src/compiler/codegen/module.mbt
@@ -23,7 +23,7 @@ pub fn emit_client_module(
   sb.write_string(emit_component_contracts(doc, component_name, true))
   sb.write_string(render_component_signature(doc, component_name, true))
   if doc.script_setup_transformed is Some(script_setup) &&
-    not(script_setup.trim().is_empty()) {
+    !(script_setup.trim().is_empty()) {
     sb.write_string(indent_block(script_setup.trim().to_string(), 2))
     sb.write_string("\n")
   }
@@ -70,7 +70,7 @@ pub fn emit_server_module(
   sb.write_string(emit_component_contracts(doc, component_name, false))
   sb.write_string(render_component_signature(doc, component_name, false))
   if doc.script_setup_transformed is Some(script_setup) &&
-    not(script_setup.trim().is_empty()) {
+    !(script_setup.trim().is_empty()) {
     sb.write_string(indent_block(script_setup.trim().to_string(), 2))
     sb.write_string("\n")
   }
@@ -98,12 +98,12 @@ fn emit_import_block(
 ) -> String {
   let merged : Array[String] = []
   for entry in base_entries {
-    if not(string_array_contains(merged, entry)) {
+    if !(string_array_contains(merged, entry)) {
       merged.push(entry)
     }
   }
   for entry in extra_entries {
-    if not(string_array_contains(merged, entry)) {
+    if !(string_array_contains(merged, entry)) {
       merged.push(entry)
     }
   }
@@ -120,7 +120,7 @@ fn emit_import_block(
 
 ///|
 fn emit_extern_script(sb : StringBuilder, doc : SfcDocument) -> Unit {
-  if doc.script_transformed is Some(script) && not(script.trim().is_empty()) {
+  if doc.script_transformed is Some(script) && !(script.trim().is_empty()) {
     sb.write_string(script.trim().to_string())
     sb.write_string("\n\n")
   }
@@ -133,12 +133,12 @@ fn merge_import_entries(
 ) -> Array[String] {
   let merged : Array[String] = []
   for entry in first {
-    if not(string_array_contains(merged, entry)) {
+    if !(string_array_contains(merged, entry)) {
       merged.push(entry)
     }
   }
   for entry in second {
-    if not(string_array_contains(merged, entry)) {
+    if !(string_array_contains(merged, entry)) {
       merged.push(entry)
     }
   }

--- a/src/compiler/codegen/utils.mbt
+++ b/src/compiler/codegen/utils.mbt
@@ -204,7 +204,7 @@ fn scope_css_rules(css : String, scope_id : String) -> String {
           }
         }
       }
-      if !(scoped_selectors.is_empty()) {
+      if !scoped_selectors.is_empty() {
         scoped_chunks.push(
           wrap_css_block(scoped_selectors.join(", "), body.trim().to_string()),
         )
@@ -497,13 +497,11 @@ fn skip_css_comment(source : String, start : Int) -> Int {
 
 ///|
 fn scopes_nested_css_rules(header : String) -> Bool {
-  !(
-    header.has_prefix("@keyframes") ||
-    header.has_prefix("@-webkit-keyframes") ||
-    header.has_prefix("@font-face") ||
-    header.has_prefix("@page") ||
-    header.has_prefix("@property"),
-  )
+  !(header.has_prefix("@keyframes") ||
+  header.has_prefix("@-webkit-keyframes") ||
+  header.has_prefix("@font-face") ||
+  header.has_prefix("@page") ||
+  header.has_prefix("@property"))
 }
 
 ///|

--- a/src/compiler/codegen/utils.mbt
+++ b/src/compiler/codegen/utils.mbt
@@ -204,7 +204,7 @@ fn scope_css_rules(css : String, scope_id : String) -> String {
           }
         }
       }
-      if not(scoped_selectors.is_empty()) {
+      if !(scoped_selectors.is_empty()) {
         scoped_chunks.push(
           wrap_css_block(scoped_selectors.join(", "), body.trim().to_string()),
         )
@@ -497,7 +497,7 @@ fn skip_css_comment(source : String, start : Int) -> Int {
 
 ///|
 fn scopes_nested_css_rules(header : String) -> Bool {
-  not(
+  !(
     header.has_prefix("@keyframes") ||
     header.has_prefix("@-webkit-keyframes") ||
     header.has_prefix("@font-face") ||

--- a/src/compiler/compiler.mbt
+++ b/src/compiler/compiler.mbt
@@ -495,7 +495,7 @@ fn script_setup_contains_legacy_emit_call(
   filename : String,
 ) -> Bool {
   let (impls, reports) = @mbt_parser.parse_string(source, name=filename)
-  if !(reports.is_empty()) {
+  if !reports.is_empty() {
     return false
   }
   for impl_ in impls {
@@ -516,7 +516,7 @@ fn parse_template_expr_ast(
     wrapped,
     name=filename + "#template-expr",
   )
-  if !(reports.is_empty()) {
+  if !reports.is_empty() {
     raise CompilerError::InvalidTemplate(
       invalid_template_expression_message(expr, filename, reports[0].msg),
     )
@@ -587,7 +587,7 @@ fn is_field_getter_call_model_target(
   func : @mbt_syntax.Expr,
   args : @list.List[@mbt_syntax.Argument],
 ) -> Bool {
-  if !(argument_list_is_empty_model_target(args)) {
+  if !argument_list_is_empty_model_target(args) {
     return false
   }
   let func = unwrap_group_expr_local(func)

--- a/src/compiler/compiler.mbt
+++ b/src/compiler/compiler.mbt
@@ -495,7 +495,7 @@ fn script_setup_contains_legacy_emit_call(
   filename : String,
 ) -> Bool {
   let (impls, reports) = @mbt_parser.parse_string(source, name=filename)
-  if not(reports.is_empty()) {
+  if !(reports.is_empty()) {
     return false
   }
   for impl_ in impls {
@@ -516,7 +516,7 @@ fn parse_template_expr_ast(
     wrapped,
     name=filename + "#template-expr",
   )
-  if not(reports.is_empty()) {
+  if !(reports.is_empty()) {
     raise CompilerError::InvalidTemplate(
       invalid_template_expression_message(expr, filename, reports[0].msg),
     )
@@ -587,7 +587,7 @@ fn is_field_getter_call_model_target(
   func : @mbt_syntax.Expr,
   args : @list.List[@mbt_syntax.Argument],
 ) -> Bool {
-  if not(argument_list_is_empty_model_target(args)) {
+  if !(argument_list_is_empty_model_target(args)) {
     return false
   }
   let func = unwrap_group_expr_local(func)

--- a/src/compiler/script_setup/analyze.mbt
+++ b/src/compiler/script_setup/analyze.mbt
@@ -148,7 +148,7 @@ fn ScriptSetupModule::analyze_contracts(
           MacroExpr(macro_) =>
             match macro_.name {
               "defineProps" =>
-                if props_binding is Some(_) || not(props.is_empty()) {
+                if props_binding is Some(_) || !(props.is_empty()) {
                   raise CompilerError::InvalidScriptSetup(
                     "duplicate defineProps() in \{resolver.filename}",
                   )
@@ -161,7 +161,7 @@ fn ScriptSetupModule::analyze_contracts(
                   )
                 }
               "defineEmits" =>
-                if emits_binding is Some(_) || not(emits.is_empty()) {
+                if emits_binding is Some(_) || !(emits.is_empty()) {
                   raise CompilerError::InvalidScriptSetup(
                     "duplicate defineEmits() in \{resolver.filename}",
                   )
@@ -169,7 +169,7 @@ fn ScriptSetupModule::analyze_contracts(
                   emits = resolver.resolve_macro_fields(macro_, None)
                 }
               "defineSlots" =>
-                if slots_binding is Some(_) || not(slots.is_empty()) {
+                if slots_binding is Some(_) || !(slots.is_empty()) {
                   raise CompilerError::InvalidScriptSetup(
                     "duplicate defineSlots() in \{resolver.filename}",
                   )
@@ -177,7 +177,7 @@ fn ScriptSetupModule::analyze_contracts(
                   slots = resolver.resolve_macro_fields(macro_, None)
                 }
               "defineExpose" =>
-                if expose_binding is Some(_) || not(expose.is_empty()) {
+                if expose_binding is Some(_) || !(expose.is_empty()) {
                   raise CompilerError::InvalidScriptSetup(
                     "duplicate defineExpose() in \{resolver.filename}",
                   )
@@ -321,7 +321,7 @@ fn ScriptSetupModule::import_entries(self : ScriptSetupModule) -> Array[String] 
     match statement {
       ImportStatement(parts) =>
         for entry in parts {
-          if not(array_contains(entries, entry)) {
+          if !(array_contains(entries, entry)) {
             entries.push(entry)
           }
         }

--- a/src/compiler/script_setup/analyze.mbt
+++ b/src/compiler/script_setup/analyze.mbt
@@ -148,7 +148,7 @@ fn ScriptSetupModule::analyze_contracts(
           MacroExpr(macro_) =>
             match macro_.name {
               "defineProps" =>
-                if props_binding is Some(_) || !(props.is_empty()) {
+                if props_binding is Some(_) || !props.is_empty() {
                   raise CompilerError::InvalidScriptSetup(
                     "duplicate defineProps() in \{resolver.filename}",
                   )
@@ -161,7 +161,7 @@ fn ScriptSetupModule::analyze_contracts(
                   )
                 }
               "defineEmits" =>
-                if emits_binding is Some(_) || !(emits.is_empty()) {
+                if emits_binding is Some(_) || !emits.is_empty() {
                   raise CompilerError::InvalidScriptSetup(
                     "duplicate defineEmits() in \{resolver.filename}",
                   )
@@ -169,7 +169,7 @@ fn ScriptSetupModule::analyze_contracts(
                   emits = resolver.resolve_macro_fields(macro_, None)
                 }
               "defineSlots" =>
-                if slots_binding is Some(_) || !(slots.is_empty()) {
+                if slots_binding is Some(_) || !slots.is_empty() {
                   raise CompilerError::InvalidScriptSetup(
                     "duplicate defineSlots() in \{resolver.filename}",
                   )
@@ -177,7 +177,7 @@ fn ScriptSetupModule::analyze_contracts(
                   slots = resolver.resolve_macro_fields(macro_, None)
                 }
               "defineExpose" =>
-                if expose_binding is Some(_) || !(expose.is_empty()) {
+                if expose_binding is Some(_) || !expose.is_empty() {
                   raise CompilerError::InvalidScriptSetup(
                     "duplicate defineExpose() in \{resolver.filename}",
                   )
@@ -321,7 +321,7 @@ fn ScriptSetupModule::import_entries(self : ScriptSetupModule) -> Array[String] 
     match statement {
       ImportStatement(parts) =>
         for entry in parts {
-          if !(array_contains(entries, entry)) {
+          if !array_contains(entries, entry) {
             entries.push(entry)
           }
         }

--- a/src/compiler/script_setup/contracts.mbt
+++ b/src/compiler/script_setup/contracts.mbt
@@ -109,7 +109,7 @@ fn is_unit_type_name(
   constr_id : @mbt_syntax.ConstrId,
   tys : @list.List[@mbt_syntax.Type],
 ) -> Bool {
-  if !(tys.is_empty()) {
+  if !tys.is_empty() {
     return false
   }
   match constr_id.id {
@@ -155,7 +155,7 @@ fn type_identifier_name(constr_id : @mbt_syntax.ConstrId) -> String {
 
 ///|
 fn push_type_identifier(identifiers : Array[String], name : String) -> Unit {
-  if !(contains_type_identifier(identifiers, name)) {
+  if !contains_type_identifier(identifiers, name) {
     identifiers.push(name)
   }
 }

--- a/src/compiler/script_setup/contracts.mbt
+++ b/src/compiler/script_setup/contracts.mbt
@@ -109,7 +109,7 @@ fn is_unit_type_name(
   constr_id : @mbt_syntax.ConstrId,
   tys : @list.List[@mbt_syntax.Type],
 ) -> Bool {
-  if not(tys.is_empty()) {
+  if !(tys.is_empty()) {
     return false
   }
   match constr_id.id {
@@ -155,7 +155,7 @@ fn type_identifier_name(constr_id : @mbt_syntax.ConstrId) -> String {
 
 ///|
 fn push_type_identifier(identifiers : Array[String], name : String) -> Unit {
-  if not(contains_type_identifier(identifiers, name)) {
+  if !(contains_type_identifier(identifiers, name)) {
     identifiers.push(name)
   }
 }

--- a/src/compiler/script_setup/imports_logic.mbt
+++ b/src/compiler/script_setup/imports_logic.mbt
@@ -1,6 +1,6 @@
 ///|
 fn ScriptSetupSource::is_import_statement(self : ScriptSetupSource) -> Bool {
-  if !(self.source.has_prefix("import")) {
+  if !self.source.has_prefix("import") {
     return false
   }
   if self.chars.length() == 6 {
@@ -24,7 +24,7 @@ fn ScriptSetupSource::expand_import_statement(
       local_aliases.push(entry)
     }
   }
-  if !(import_entries.is_empty()) {
+  if !import_entries.is_empty() {
     statements.push(ImportStatement(import_entries))
   }
   for local_binding in local_aliases {

--- a/src/compiler/script_setup/imports_logic.mbt
+++ b/src/compiler/script_setup/imports_logic.mbt
@@ -1,6 +1,6 @@
 ///|
 fn ScriptSetupSource::is_import_statement(self : ScriptSetupSource) -> Bool {
-  if not(self.source.has_prefix("import")) {
+  if !(self.source.has_prefix("import")) {
     return false
   }
   if self.chars.length() == 6 {
@@ -24,7 +24,7 @@ fn ScriptSetupSource::expand_import_statement(
       local_aliases.push(entry)
     }
   }
-  if not(import_entries.is_empty()) {
+  if !(import_entries.is_empty()) {
     statements.push(ImportStatement(import_entries))
   }
   for local_binding in local_aliases {

--- a/src/compiler/script_setup/parse.mbt
+++ b/src/compiler/script_setup/parse.mbt
@@ -97,7 +97,7 @@ fn ScriptSetupContractResolver::validate_interface_fields(
 ) -> Array[MacroField] raise CompilerError {
   let validated : Array[MacroField] = []
   for field in fields {
-    if !(is_identifier_literal(field.name)) {
+    if !is_identifier_literal(field.name) {
       raise CompilerError::InvalidScriptSetup(
         "\{macro_name}() entries must be identifier-like for typed interfaces in \{self.filename}: \{field.name}",
       )

--- a/src/compiler/script_setup/parse.mbt
+++ b/src/compiler/script_setup/parse.mbt
@@ -97,7 +97,7 @@ fn ScriptSetupContractResolver::validate_interface_fields(
 ) -> Array[MacroField] raise CompilerError {
   let validated : Array[MacroField] = []
   for field in fields {
-    if not(is_identifier_literal(field.name)) {
+    if !(is_identifier_literal(field.name)) {
       raise CompilerError::InvalidScriptSetup(
         "\{macro_name}() entries must be identifier-like for typed interfaces in \{self.filename}: \{field.name}",
       )

--- a/src/compiler/script_setup/scan.mbt
+++ b/src/compiler/script_setup/scan.mbt
@@ -17,7 +17,7 @@ fn ScriptSetupSource::parse_module_with_contracts(
       continue
     }
     let (impls, reports) = @mbt_parser.parse_string(trimmed, name=self.filename)
-    if not(reports.is_empty()) {
+    if !(reports.is_empty()) {
       raise CompilerError::InvalidScriptSetup(reports[0].to_string())
     }
     for impl_ in impls {

--- a/src/compiler/script_setup/scan.mbt
+++ b/src/compiler/script_setup/scan.mbt
@@ -17,7 +17,7 @@ fn ScriptSetupSource::parse_module_with_contracts(
       continue
     }
     let (impls, reports) = @mbt_parser.parse_string(trimmed, name=self.filename)
-    if !(reports.is_empty()) {
+    if !reports.is_empty() {
       raise CompilerError::InvalidScriptSetup(reports[0].to_string())
     }
     for impl_ in impls {

--- a/src/compiler/script_setup/source.mbt
+++ b/src/compiler/script_setup/source.mbt
@@ -56,7 +56,7 @@ fn ScriptSetupSource::split_top_level_statements(
     bracket_depth = depths.1
     brace_depth = depths.2
     if (current == '\n' || current == ';') &&
-      not(
+      !(
         self.continues_top_level_statement(start, cursor, cursor + 1, current),
       ) &&
       paren_depth == 0 &&
@@ -177,7 +177,7 @@ fn ScriptSetupSource::starts_with_continuation_word(
   start : Int,
   expected : String,
 ) -> Bool {
-  if not(self.starts_with(start, expected)) {
+  if !(self.starts_with(start, expected)) {
     return false
   }
   let end_ = start + expected.length()

--- a/src/compiler/script_setup/source.mbt
+++ b/src/compiler/script_setup/source.mbt
@@ -56,9 +56,7 @@ fn ScriptSetupSource::split_top_level_statements(
     bracket_depth = depths.1
     brace_depth = depths.2
     if (current == '\n' || current == ';') &&
-      !(
-        self.continues_top_level_statement(start, cursor, cursor + 1, current),
-      ) &&
+      !self.continues_top_level_statement(start, cursor, cursor + 1, current) &&
       paren_depth == 0 &&
       bracket_depth == 0 &&
       brace_depth == 0 {
@@ -177,7 +175,7 @@ fn ScriptSetupSource::starts_with_continuation_word(
   start : Int,
   expected : String,
 ) -> Bool {
-  if !(self.starts_with(start, expected)) {
+  if !self.starts_with(start, expected) {
     return false
   }
   let end_ = start + expected.length()

--- a/src/compiler/script_setup/utils.mbt
+++ b/src/compiler/script_setup/utils.mbt
@@ -95,11 +95,9 @@ fn ScriptSetupSource::starts_multiline_string_line(
   self : ScriptSetupSource,
   start : Int,
 ) -> Bool {
-  if !(
-      start + 1 < self.chars.length() &&
-      self.chars[start] == '#' &&
-      self.chars[start + 1] == '|',
-    ) {
+  if !(start + 1 < self.chars.length() &&
+    self.chars[start] == '#' &&
+    self.chars[start + 1] == '|') {
     return false
   }
   let mut cursor = start
@@ -138,16 +136,14 @@ fn is_identifier_literal(source : String) -> Bool {
     return false
   }
   let first = source[0].to_int()
-  if !(
-      (first >= 'a'.to_int() && first <= 'z'.to_int()) ||
-      (first >= 'A'.to_int() && first <= 'Z'.to_int()) ||
-      first == '_'.to_int() ||
-      first == '$'.to_int(),
-    ) {
+  if !((first >= 'a'.to_int() && first <= 'z'.to_int()) ||
+    (first >= 'A'.to_int() && first <= 'Z'.to_int()) ||
+    first == '_'.to_int() ||
+    first == '$'.to_int()) {
     return false
   }
   for i in 1..<source.length() {
-    if !(is_identifier_charcode(source[i].to_int())) {
+    if !is_identifier_charcode(source[i].to_int()) {
       return false
     }
   }

--- a/src/compiler/script_setup/utils.mbt
+++ b/src/compiler/script_setup/utils.mbt
@@ -95,7 +95,7 @@ fn ScriptSetupSource::starts_multiline_string_line(
   self : ScriptSetupSource,
   start : Int,
 ) -> Bool {
-  if not(
+  if !(
       start + 1 < self.chars.length() &&
       self.chars[start] == '#' &&
       self.chars[start + 1] == '|',
@@ -138,7 +138,7 @@ fn is_identifier_literal(source : String) -> Bool {
     return false
   }
   let first = source[0].to_int()
-  if not(
+  if !(
       (first >= 'a'.to_int() && first <= 'z'.to_int()) ||
       (first >= 'A'.to_int() && first <= 'Z'.to_int()) ||
       first == '_'.to_int() ||
@@ -147,7 +147,7 @@ fn is_identifier_literal(source : String) -> Bool {
     return false
   }
   for i in 1..<source.length() {
-    if not(is_identifier_charcode(source[i].to_int())) {
+    if !(is_identifier_charcode(source[i].to_int())) {
       return false
     }
   }

--- a/src/compiler/sfc/blocks.mbt
+++ b/src/compiler/sfc/blocks.mbt
@@ -34,7 +34,7 @@ fn parse_blocks(
     }
     match read_start_tag(source, chars, cursor, filename) {
       Some((tag, attrs, tag_end, self_closing)) => {
-        if !(is_top_level_tag(tag)) {
+        if !is_top_level_tag(tag) {
           raise CompilerError::InvalidSfc(
             "unexpected top-level tag <\{tag}> in \{filename}",
           )

--- a/src/compiler/sfc/blocks.mbt
+++ b/src/compiler/sfc/blocks.mbt
@@ -34,7 +34,7 @@ fn parse_blocks(
     }
     match read_start_tag(source, chars, cursor, filename) {
       Some((tag, attrs, tag_end, self_closing)) => {
-        if not(is_top_level_tag(tag)) {
+        if !(is_top_level_tag(tag)) {
           raise CompilerError::InvalidSfc(
             "unexpected top-level tag <\{tag}> in \{filename}",
           )

--- a/src/compiler/sfc/blocks_scan.mbt
+++ b/src/compiler/sfc/blocks_scan.mbt
@@ -23,7 +23,7 @@ fn find_template_block_close(
               return Some(cursor)
             }
             nested_template_depth -= 1
-          } else if !(self_closing) {
+          } else if !self_closing {
             nested_template_depth += 1
           }
         }
@@ -81,11 +81,9 @@ fn find_raw_block_close(
 
 ///|
 fn starts_raw_multiline_string_line(chars : Array[Char], start : Int) -> Bool {
-  if !(
-      start + 1 < chars.length() &&
-      chars[start] == '#' &&
-      chars[start + 1] == '|',
-    ) {
+  if !(start + 1 < chars.length() &&
+    chars[start] == '#' &&
+    chars[start + 1] == '|') {
     return false
   }
   let mut cursor = start

--- a/src/compiler/sfc/blocks_scan.mbt
+++ b/src/compiler/sfc/blocks_scan.mbt
@@ -23,7 +23,7 @@ fn find_template_block_close(
               return Some(cursor)
             }
             nested_template_depth -= 1
-          } else if not(self_closing) {
+          } else if !(self_closing) {
             nested_template_depth += 1
           }
         }
@@ -81,7 +81,7 @@ fn find_raw_block_close(
 
 ///|
 fn starts_raw_multiline_string_line(chars : Array[Char], start : Int) -> Bool {
-  if not(
+  if !(
       start + 1 < chars.length() &&
       chars[start] == '#' &&
       chars[start + 1] == '|',

--- a/src/compiler/sfc/generics.mbt
+++ b/src/compiler/sfc/generics.mbt
@@ -255,16 +255,14 @@ fn is_identifier_literal(source : String) -> Bool {
     return false
   }
   let first = source[0].to_int()
-  if !(
-      (first >= 'a'.to_int() && first <= 'z'.to_int()) ||
-      (first >= 'A'.to_int() && first <= 'Z'.to_int()) ||
-      first == '_'.to_int() ||
-      first == '$'.to_int(),
-    ) {
+  if !((first >= 'a'.to_int() && first <= 'z'.to_int()) ||
+    (first >= 'A'.to_int() && first <= 'Z'.to_int()) ||
+    first == '_'.to_int() ||
+    first == '$'.to_int()) {
     return false
   }
   for i in 1..<source.length() {
-    if !(is_identifier_charcode(source[i].to_int())) {
+    if !is_identifier_charcode(source[i].to_int()) {
       return false
     }
   }

--- a/src/compiler/sfc/generics.mbt
+++ b/src/compiler/sfc/generics.mbt
@@ -255,7 +255,7 @@ fn is_identifier_literal(source : String) -> Bool {
     return false
   }
   let first = source[0].to_int()
-  if not(
+  if !(
       (first >= 'a'.to_int() && first <= 'z'.to_int()) ||
       (first >= 'A'.to_int() && first <= 'Z'.to_int()) ||
       first == '_'.to_int() ||
@@ -264,7 +264,7 @@ fn is_identifier_literal(source : String) -> Bool {
     return false
   }
   for i in 1..<source.length() {
-    if not(is_identifier_charcode(source[i].to_int())) {
+    if !(is_identifier_charcode(source[i].to_int())) {
       return false
     }
   }

--- a/src/compiler/sfc/tag.mbt
+++ b/src/compiler/sfc/tag.mbt
@@ -55,7 +55,7 @@ fn validate_block_attrs(
       )
     }
     seen.push(attr.name)
-    if not(is_supported_block_attr(block.kind, attr.name)) {
+    if !(is_supported_block_attr(block.kind, attr.name)) {
       match attr.name {
         "setup" =>
           if block.kind == ScriptExtern {
@@ -110,7 +110,7 @@ fn validate_block_attrs(
         }
       "scoped" =>
         match attr.value {
-          Some(value) if not(is_scoped_style_disabled_value(value)) =>
+          Some(value) if !(is_scoped_style_disabled_value(value)) =>
             raise CompilerError::InvalidSfc(
               "`scoped` only accepts `false` on <style> in \{filename}",
             )
@@ -178,7 +178,7 @@ fn find_attr_value(attrs : Array[BlockAttr], name : String) -> String? {
 ///|
 fn style_block_is_scoped(attrs : Array[BlockAttr]) -> Bool {
   match find_attr_value(attrs, "scoped") {
-    Some(value) => not(is_scoped_style_disabled_value(value))
+    Some(value) => !(is_scoped_style_disabled_value(value))
     None => true
   }
 }
@@ -305,7 +305,7 @@ fn parse_block_attrs(
     }
     let name_start = cursor
     if cursor >= chars.length() ||
-      not(is_block_attr_name_start_char(chars[cursor])) {
+      !(is_block_attr_name_start_char(chars[cursor])) {
       raise CompilerError::InvalidSfc(
         "expected attribute name in <\{tag}> start tag of \{filename}",
       )
@@ -365,8 +365,8 @@ fn read_attr_value(
   } else {
     let mut cursor = start
     while cursor < chars.length() &&
-          not(is_block_space(chars[cursor])) &&
-          not(is_attr_value_self_closing_boundary(chars, cursor)) {
+          !(is_block_space(chars[cursor])) &&
+          !(is_attr_value_self_closing_boundary(chars, cursor)) {
       cursor += 1
     }
     if cursor == start {

--- a/src/compiler/sfc/tag.mbt
+++ b/src/compiler/sfc/tag.mbt
@@ -55,7 +55,7 @@ fn validate_block_attrs(
       )
     }
     seen.push(attr.name)
-    if !(is_supported_block_attr(block.kind, attr.name)) {
+    if !is_supported_block_attr(block.kind, attr.name) {
       match attr.name {
         "setup" =>
           if block.kind == ScriptExtern {
@@ -110,7 +110,7 @@ fn validate_block_attrs(
         }
       "scoped" =>
         match attr.value {
-          Some(value) if !(is_scoped_style_disabled_value(value)) =>
+          Some(value) if !is_scoped_style_disabled_value(value) =>
             raise CompilerError::InvalidSfc(
               "`scoped` only accepts `false` on <style> in \{filename}",
             )
@@ -178,7 +178,7 @@ fn find_attr_value(attrs : Array[BlockAttr], name : String) -> String? {
 ///|
 fn style_block_is_scoped(attrs : Array[BlockAttr]) -> Bool {
   match find_attr_value(attrs, "scoped") {
-    Some(value) => !(is_scoped_style_disabled_value(value))
+    Some(value) => !is_scoped_style_disabled_value(value)
     None => true
   }
 }
@@ -304,8 +304,7 @@ fn parse_block_attrs(
       )
     }
     let name_start = cursor
-    if cursor >= chars.length() ||
-      !(is_block_attr_name_start_char(chars[cursor])) {
+    if cursor >= chars.length() || !is_block_attr_name_start_char(chars[cursor]) {
       raise CompilerError::InvalidSfc(
         "expected attribute name in <\{tag}> start tag of \{filename}",
       )
@@ -365,8 +364,8 @@ fn read_attr_value(
   } else {
     let mut cursor = start
     while cursor < chars.length() &&
-          !(is_block_space(chars[cursor])) &&
-          !(is_attr_value_self_closing_boundary(chars, cursor)) {
+          !is_block_space(chars[cursor]) &&
+          !is_attr_value_self_closing_boundary(chars, cursor) {
       cursor += 1
     }
     if cursor == start {

--- a/src/compiler/template/builder.mbt
+++ b/src/compiler/template/builder.mbt
@@ -12,7 +12,7 @@ fn visitor_on_text(
   end_ : Int,
   has_content : Bool,
 ) -> Unit raise CompilerError {
-  if not(has_content) {
+  if !(has_content) {
     return
   }
   append_node(
@@ -277,7 +277,7 @@ fn apply_case_directive(
     )
   }
   ensure_empty_expr_directive(state.case_pattern, attr, tag)
-  if not(attr.has_value) {
+  if !(attr.has_value) {
     raise CompilerError::InvalidDirective(
       "`v-case` requires a pattern value on <\{tag}>; use `v-default` for the fallback branch",
     )
@@ -330,7 +330,7 @@ fn with_island_mode(
   next_mode : IslandMode,
   keeps_value : Bool,
 ) -> TemplateElementBuildState raise CompilerError {
-  if not(keeps_value) {
+  if !(keeps_value) {
     reject_unexpected_attr_value(attr, state.tag)
   }
   {
@@ -545,7 +545,7 @@ fn append_node(
       if element.else_if_expr is Some(_) || element.is_else {
         append_conditional_branch(target, element)
       } else if (element.case_pattern is Some(_) || element.is_case_default) &&
-        not(parent_has_match) {
+        !(parent_has_match) {
         raise CompilerError::InvalidDirective(
           "`v-case` must be a direct child of a `v-match` element on <" +
           element.tag +
@@ -643,7 +643,7 @@ fn build_match_node(
           "interpolation is not allowed as direct child of `v-match` on <\{tag}>",
         )
       Element(element) => {
-        if element.case_pattern is None && not(element.is_case_default) {
+        if element.case_pattern is None && !(element.is_case_default) {
           raise CompilerError::InvalidDirective(
             "direct children of `v-match` must use `v-case` on <\{tag}>: found <\{element.tag}> without `v-case`",
           )

--- a/src/compiler/template/builder.mbt
+++ b/src/compiler/template/builder.mbt
@@ -12,7 +12,7 @@ fn visitor_on_text(
   end_ : Int,
   has_content : Bool,
 ) -> Unit raise CompilerError {
-  if !(has_content) {
+  if !has_content {
     return
   }
   append_node(
@@ -277,7 +277,7 @@ fn apply_case_directive(
     )
   }
   ensure_empty_expr_directive(state.case_pattern, attr, tag)
-  if !(attr.has_value) {
+  if !attr.has_value {
     raise CompilerError::InvalidDirective(
       "`v-case` requires a pattern value on <\{tag}>; use `v-default` for the fallback branch",
     )
@@ -330,7 +330,7 @@ fn with_island_mode(
   next_mode : IslandMode,
   keeps_value : Bool,
 ) -> TemplateElementBuildState raise CompilerError {
-  if !(keeps_value) {
+  if !keeps_value {
     reject_unexpected_attr_value(attr, state.tag)
   }
   {
@@ -545,7 +545,7 @@ fn append_node(
       if element.else_if_expr is Some(_) || element.is_else {
         append_conditional_branch(target, element)
       } else if (element.case_pattern is Some(_) || element.is_case_default) &&
-        !(parent_has_match) {
+        !parent_has_match {
         raise CompilerError::InvalidDirective(
           "`v-case` must be a direct child of a `v-match` element on <" +
           element.tag +
@@ -643,7 +643,7 @@ fn build_match_node(
           "interpolation is not allowed as direct child of `v-match` on <\{tag}>",
         )
       Element(element) => {
-        if element.case_pattern is None && !(element.is_case_default) {
+        if element.case_pattern is None && !element.is_case_default {
           raise CompilerError::InvalidDirective(
             "direct children of `v-match` must use `v-case` on <\{tag}>: found <\{element.tag}> without `v-case`",
           )

--- a/src/compiler/template/builder_attrs.mbt
+++ b/src/compiler/template/builder_attrs.mbt
@@ -5,10 +5,10 @@
 fn parse_model_attr(
   attr : ParsedTemplateAttr,
 ) -> TemplateModel? raise CompilerError {
-  if not(attr.name.has_prefix("v-model")) {
+  if !(attr.name.has_prefix("v-model")) {
     return None
   }
-  if not(attr.has_value) || attr.value.trim().is_empty() {
+  if !(attr.has_value) || attr.value.trim().is_empty() {
     raise CompilerError::InvalidDirective(
       "`\{attr.name}` requires an expression",
     )

--- a/src/compiler/template/builder_attrs.mbt
+++ b/src/compiler/template/builder_attrs.mbt
@@ -5,10 +5,10 @@
 fn parse_model_attr(
   attr : ParsedTemplateAttr,
 ) -> TemplateModel? raise CompilerError {
-  if !(attr.name.has_prefix("v-model")) {
+  if !attr.name.has_prefix("v-model") {
     return None
   }
-  if !(attr.has_value) || attr.value.trim().is_empty() {
+  if !attr.has_value || attr.value.trim().is_empty() {
     raise CompilerError::InvalidDirective(
       "`\{attr.name}` requires an expression",
     )

--- a/src/compiler/template/builder_validate.mbt
+++ b/src/compiler/template/builder_validate.mbt
@@ -4,7 +4,7 @@ fn validate_finalized_element(
   children : Array[TemplateNode],
 ) -> Unit raise CompilerError {
   if is_void_html_tag(element.tag) {
-    if !(children.is_empty()) {
+    if !children.is_empty() {
       raise CompilerError::InvalidTemplate(
         "void element <\{element.tag}> cannot have children",
       )
@@ -15,7 +15,7 @@ fn validate_finalized_element(
       raise CompilerError::InvalidDirective(
         "v-unsafe-html is not supported on void elements: <\{element.tag}>",
       )
-    Some(_) if !(children.is_empty()) =>
+    Some(_) if !children.is_empty() =>
       raise CompilerError::InvalidDirective(
         "v-unsafe-html cannot be combined with child nodes on <\{element.tag}>",
       )
@@ -43,7 +43,7 @@ fn expect_attr_value(
   attr : ParsedTemplateAttr,
   tag : String,
 ) -> String raise CompilerError {
-  if attr.has_value && !(attr.value.trim().is_empty()) {
+  if attr.has_value && !attr.value.trim().is_empty() {
     return attr.value
   }
   raise CompilerError::InvalidDirective(
@@ -68,7 +68,7 @@ fn validate_element_tag_form(
   tag : String,
   self_closing : Bool,
 ) -> Unit raise CompilerError {
-  if is_void_html_tag(tag) && !(self_closing) {
+  if is_void_html_tag(tag) && !self_closing {
     raise CompilerError::InvalidTemplate(
       "void element <\{tag}> must be self closing",
     )
@@ -94,7 +94,7 @@ fn validate_normalized_attr(
         )
       }
       validate_event_modifiers(attr, tag)
-      if !(raw_attr.has_value) || raw_attr.value.trim().is_empty() {
+      if !raw_attr.has_value || raw_attr.value.trim().is_empty() {
         raise CompilerError::InvalidDirective(
           "`\{raw_attr.name}` requires an expression",
         )
@@ -135,7 +135,7 @@ fn validate_normalized_attr_conflict(
         )
       }
     _ =>
-      if !(is_mergeable_attr_name(attr.name)) &&
+      if !is_mergeable_attr_name(attr.name) &&
         has_non_event_attr(attrs, attr.name) {
         raise CompilerError::InvalidDirective(
           "duplicate attribute `\{attr.name}` on <\{tag}>",
@@ -310,17 +310,17 @@ fn validate_component_bindings(
       "`<component>` requires `:is` or `v-bind:is`",
     )
   }
-  if tag == "Teleport" && !(has_non_event_attr(attrs, "to")) {
+  if tag == "Teleport" && !has_non_event_attr(attrs, "to") {
     raise CompilerError::InvalidDirective("`<Teleport>` requires a `to` prop")
   }
   match island_directive {
-    Some(_) if !(is_component) =>
+    Some(_) if !is_component =>
       raise CompilerError::InvalidDirective(
         "island directives can only be used on component tags: <\{tag}>",
       )
     _ => ()
   }
-  if !(is_component) {
+  if !is_component {
     match html_expr {
       Some(_) if is_void_html_tag(tag) =>
         raise CompilerError::InvalidDirective(
@@ -373,7 +373,7 @@ fn validate_event_modifiers(
   let mut has_passive = false
   let mut has_prevent = false
   for modifier in attr.modifiers {
-    if !(is_supported_event_modifier(modifier)) {
+    if !is_supported_event_modifier(modifier) {
       raise CompilerError::InvalidDirective(
         "unsupported event modifier `.\{modifier}` on <\{tag}>",
       )

--- a/src/compiler/template/builder_validate.mbt
+++ b/src/compiler/template/builder_validate.mbt
@@ -4,7 +4,7 @@ fn validate_finalized_element(
   children : Array[TemplateNode],
 ) -> Unit raise CompilerError {
   if is_void_html_tag(element.tag) {
-    if not(children.is_empty()) {
+    if !(children.is_empty()) {
       raise CompilerError::InvalidTemplate(
         "void element <\{element.tag}> cannot have children",
       )
@@ -15,7 +15,7 @@ fn validate_finalized_element(
       raise CompilerError::InvalidDirective(
         "v-unsafe-html is not supported on void elements: <\{element.tag}>",
       )
-    Some(_) if not(children.is_empty()) =>
+    Some(_) if !(children.is_empty()) =>
       raise CompilerError::InvalidDirective(
         "v-unsafe-html cannot be combined with child nodes on <\{element.tag}>",
       )
@@ -43,7 +43,7 @@ fn expect_attr_value(
   attr : ParsedTemplateAttr,
   tag : String,
 ) -> String raise CompilerError {
-  if attr.has_value && not(attr.value.trim().is_empty()) {
+  if attr.has_value && !(attr.value.trim().is_empty()) {
     return attr.value
   }
   raise CompilerError::InvalidDirective(
@@ -68,7 +68,7 @@ fn validate_element_tag_form(
   tag : String,
   self_closing : Bool,
 ) -> Unit raise CompilerError {
-  if is_void_html_tag(tag) && not(self_closing) {
+  if is_void_html_tag(tag) && !(self_closing) {
     raise CompilerError::InvalidTemplate(
       "void element <\{tag}> must be self closing",
     )
@@ -94,7 +94,7 @@ fn validate_normalized_attr(
         )
       }
       validate_event_modifiers(attr, tag)
-      if not(raw_attr.has_value) || raw_attr.value.trim().is_empty() {
+      if !(raw_attr.has_value) || raw_attr.value.trim().is_empty() {
         raise CompilerError::InvalidDirective(
           "`\{raw_attr.name}` requires an expression",
         )
@@ -135,7 +135,7 @@ fn validate_normalized_attr_conflict(
         )
       }
     _ =>
-      if not(is_mergeable_attr_name(attr.name)) &&
+      if !(is_mergeable_attr_name(attr.name)) &&
         has_non_event_attr(attrs, attr.name) {
         raise CompilerError::InvalidDirective(
           "duplicate attribute `\{attr.name}` on <\{tag}>",
@@ -310,17 +310,17 @@ fn validate_component_bindings(
       "`<component>` requires `:is` or `v-bind:is`",
     )
   }
-  if tag == "Teleport" && not(has_non_event_attr(attrs, "to")) {
+  if tag == "Teleport" && !(has_non_event_attr(attrs, "to")) {
     raise CompilerError::InvalidDirective("`<Teleport>` requires a `to` prop")
   }
   match island_directive {
-    Some(_) if not(is_component) =>
+    Some(_) if !(is_component) =>
       raise CompilerError::InvalidDirective(
         "island directives can only be used on component tags: <\{tag}>",
       )
     _ => ()
   }
-  if not(is_component) {
+  if !(is_component) {
     match html_expr {
       Some(_) if is_void_html_tag(tag) =>
         raise CompilerError::InvalidDirective(
@@ -373,7 +373,7 @@ fn validate_event_modifiers(
   let mut has_passive = false
   let mut has_prevent = false
   for modifier in attr.modifiers {
-    if not(is_supported_event_modifier(modifier)) {
+    if !(is_supported_event_modifier(modifier)) {
       raise CompilerError::InvalidDirective(
         "unsupported event modifier `.\{modifier}` on <\{tag}>",
       )

--- a/src/compiler/template/parser.mbt
+++ b/src/compiler/template/parser.mbt
@@ -170,7 +170,7 @@ fn try_parse_for_separator(
 ) -> Int? {
   let keyword_start = skip_for_separator_gap(source, chars, start)
   if keyword_start == start ||
-    not(starts_with_for_local(source, keyword_start, "in")) {
+    !(starts_with_for_local(source, keyword_start, "in")) {
     return None
   }
   let right_start = skip_for_separator_gap(source, chars, keyword_start + 2)
@@ -366,7 +366,7 @@ fn skip_for_quoted(chars : Array[Char], start : Int, marker : Char) -> Int {
 
 ///|
 fn starts_for_multiline_string_line(chars : Array[Char], start : Int) -> Bool {
-  if not(
+  if !(
       start + 1 < chars.length() &&
       chars[start] == '#' &&
       chars[start + 1] == '|',
@@ -450,7 +450,7 @@ fn ensure_valid_for_binding_name(
   name : String,
   source : String,
 ) -> Unit raise CompilerError {
-  if not(is_identifier_literal(name)) {
+  if !(is_identifier_literal(name)) {
     raise CompilerError::InvalidDirective("invalid v-for binding: \{source}")
   }
 }
@@ -461,7 +461,7 @@ fn is_identifier_literal(source : String) -> Bool {
     return false
   }
   let first = source[0].to_int()
-  if not(
+  if !(
       (first >= 'a'.to_int() && first <= 'z'.to_int()) ||
       (first >= 'A'.to_int() && first <= 'Z'.to_int()) ||
       first == '_'.to_int() ||
@@ -470,7 +470,7 @@ fn is_identifier_literal(source : String) -> Bool {
     return false
   }
   for i in 1..<source.length() {
-    if not(is_identifier_charcode(source[i].to_int())) {
+    if !(is_identifier_charcode(source[i].to_int())) {
       return false
     }
   }

--- a/src/compiler/template/parser.mbt
+++ b/src/compiler/template/parser.mbt
@@ -170,7 +170,7 @@ fn try_parse_for_separator(
 ) -> Int? {
   let keyword_start = skip_for_separator_gap(source, chars, start)
   if keyword_start == start ||
-    !(starts_with_for_local(source, keyword_start, "in")) {
+    !starts_with_for_local(source, keyword_start, "in") {
     return None
   }
   let right_start = skip_for_separator_gap(source, chars, keyword_start + 2)
@@ -366,11 +366,9 @@ fn skip_for_quoted(chars : Array[Char], start : Int, marker : Char) -> Int {
 
 ///|
 fn starts_for_multiline_string_line(chars : Array[Char], start : Int) -> Bool {
-  if !(
-      start + 1 < chars.length() &&
-      chars[start] == '#' &&
-      chars[start + 1] == '|',
-    ) {
+  if !(start + 1 < chars.length() &&
+    chars[start] == '#' &&
+    chars[start + 1] == '|') {
     return false
   }
   let mut cursor = start
@@ -450,7 +448,7 @@ fn ensure_valid_for_binding_name(
   name : String,
   source : String,
 ) -> Unit raise CompilerError {
-  if !(is_identifier_literal(name)) {
+  if !is_identifier_literal(name) {
     raise CompilerError::InvalidDirective("invalid v-for binding: \{source}")
   }
 }
@@ -461,16 +459,14 @@ fn is_identifier_literal(source : String) -> Bool {
     return false
   }
   let first = source[0].to_int()
-  if !(
-      (first >= 'a'.to_int() && first <= 'z'.to_int()) ||
-      (first >= 'A'.to_int() && first <= 'Z'.to_int()) ||
-      first == '_'.to_int() ||
-      first == '$'.to_int(),
-    ) {
+  if !((first >= 'a'.to_int() && first <= 'z'.to_int()) ||
+    (first >= 'A'.to_int() && first <= 'Z'.to_int()) ||
+    first == '_'.to_int() ||
+    first == '$'.to_int()) {
     return false
   }
   for i in 1..<source.length() {
-    if !(is_identifier_charcode(source[i].to_int())) {
+    if !is_identifier_charcode(source[i].to_int()) {
       return false
     }
   }

--- a/src/compiler/template/tag.mbt
+++ b/src/compiler/template/tag.mbt
@@ -52,7 +52,7 @@ fn parse_template_attr(
   let mut cursor = start
   let name_start = cursor
   if cursor >= chars.length() ||
-    !(is_template_attr_name_start_char(chars[cursor])) {
+    !is_template_attr_name_start_char(chars[cursor]) {
     raise CompilerError::InvalidTemplate(
       "expected attribute name in start tag <\{tag}>",
     )
@@ -109,9 +109,9 @@ fn read_template_attr_value(
   }
   let mut cursor = start
   while cursor < chars.length() &&
-        !(is_space(chars[cursor])) &&
+        !is_space(chars[cursor]) &&
         chars[cursor] != '>' &&
-        !(is_self_closing_value_boundary(chars, cursor)) {
+        !is_self_closing_value_boundary(chars, cursor) {
     cursor += 1
   }
   if cursor == start {

--- a/src/compiler/template/tag.mbt
+++ b/src/compiler/template/tag.mbt
@@ -52,7 +52,7 @@ fn parse_template_attr(
   let mut cursor = start
   let name_start = cursor
   if cursor >= chars.length() ||
-    not(is_template_attr_name_start_char(chars[cursor])) {
+    !(is_template_attr_name_start_char(chars[cursor])) {
     raise CompilerError::InvalidTemplate(
       "expected attribute name in start tag <\{tag}>",
     )
@@ -109,9 +109,9 @@ fn read_template_attr_value(
   }
   let mut cursor = start
   while cursor < chars.length() &&
-        not(is_space(chars[cursor])) &&
+        !(is_space(chars[cursor])) &&
         chars[cursor] != '>' &&
-        not(is_self_closing_value_boundary(chars, cursor)) {
+        !(is_self_closing_value_boundary(chars, cursor)) {
     cursor += 1
   }
   if cursor == start {

--- a/src/compiler/template/text.mbt
+++ b/src/compiler/template/text.mbt
@@ -47,7 +47,7 @@ fn starts_template_multiline_string_line(
   chars : Array[Char],
   start : Int,
 ) -> Bool {
-  if not(
+  if !(
       start + 1 < chars.length() &&
       chars[start] == '#' &&
       chars[start + 1] == '|',
@@ -303,7 +303,7 @@ fn html_entity_digit_value(c : Char, is_hex : Bool) -> Int? {
   if c >= '0' && c <= '9' {
     return Some(c.to_int() - '0'.to_int())
   }
-  if not(is_hex) {
+  if !(is_hex) {
     return None
   }
   if c >= 'a' && c <= 'f' {
@@ -317,7 +317,7 @@ fn html_entity_digit_value(c : Char, is_hex : Bool) -> Int? {
 
 ///|
 fn is_valid_html_entity_codepoint(value : Int) -> Bool {
-  value > 0 && value <= 0x10FFFF && not(value >= 0xD800 && value <= 0xDFFF)
+  value > 0 && value <= 0x10FFFF && !(value >= 0xD800 && value <= 0xDFFF)
 }
 
 ///|

--- a/src/compiler/template/text.mbt
+++ b/src/compiler/template/text.mbt
@@ -47,11 +47,9 @@ fn starts_template_multiline_string_line(
   chars : Array[Char],
   start : Int,
 ) -> Bool {
-  if !(
-      start + 1 < chars.length() &&
-      chars[start] == '#' &&
-      chars[start + 1] == '|',
-    ) {
+  if !(start + 1 < chars.length() &&
+    chars[start] == '#' &&
+    chars[start + 1] == '|') {
     return false
   }
   let mut cursor = start
@@ -303,7 +301,7 @@ fn html_entity_digit_value(c : Char, is_hex : Bool) -> Int? {
   if c >= '0' && c <= '9' {
     return Some(c.to_int() - '0'.to_int())
   }
-  if !(is_hex) {
+  if !is_hex {
     return None
   }
   if c >= 'a' && c <= 'f' {

--- a/src/compiler/template/tokens.mbt
+++ b/src/compiler/template/tokens.mbt
@@ -30,7 +30,7 @@ fn visit_template_tokens(
           text_has_content = false
           state = TemplateTokenizerState::TagOpen
         } else {
-          if not(is_space(chars[cursor])) {
+          if !(is_space(chars[cursor])) {
             text_has_content = true
           }
           cursor += 1
@@ -143,7 +143,7 @@ fn is_comment_open(chars : Array[Char], start : Int) -> Bool {
 
 ///|
 fn is_end_tag_open(chars : Array[Char], start : Int) -> Bool {
-  if not(
+  if !(
       start + 1 < chars.length() &&
       chars[start] == '<' &&
       chars[start + 1] == '/',

--- a/src/compiler/template/tokens.mbt
+++ b/src/compiler/template/tokens.mbt
@@ -30,7 +30,7 @@ fn visit_template_tokens(
           text_has_content = false
           state = TemplateTokenizerState::TagOpen
         } else {
-          if !(is_space(chars[cursor])) {
+          if !is_space(chars[cursor]) {
             text_has_content = true
           }
           cursor += 1
@@ -143,11 +143,9 @@ fn is_comment_open(chars : Array[Char], start : Int) -> Bool {
 
 ///|
 fn is_end_tag_open(chars : Array[Char], start : Int) -> Bool {
-  if !(
-      start + 1 < chars.length() &&
-      chars[start] == '<' &&
-      chars[start + 1] == '/',
-    ) {
+  if !(start + 1 < chars.length() &&
+    chars[start] == '<' &&
+    chars[start + 1] == '/') {
     return false
   }
   let mut cursor = start + 2

--- a/src/compiler/test_support/helpers.mbt
+++ b/src/compiler/test_support/helpers.mbt
@@ -124,13 +124,13 @@ fn collect_client_temp_names(source : String) -> Array[String] {
   let lines = source.split("\n").map(fn(line) { line.to_string() }).collect()
   for line in lines {
     let trimmed = line.trim().to_string()
-    if not(trimmed.has_prefix("let ")) {
+    if !(trimmed.has_prefix("let ")) {
       continue
     }
     match trimmed.find(" = @dom.el(") {
       Some(index) => {
         let name = String::unsafe_substring(trimmed, start=4, end=index)
-        if not(temp_name_list_contains(names, name)) {
+        if !(temp_name_list_contains(names, name)) {
           names.push(name)
         }
       }

--- a/src/compiler/test_support/helpers.mbt
+++ b/src/compiler/test_support/helpers.mbt
@@ -124,13 +124,13 @@ fn collect_client_temp_names(source : String) -> Array[String] {
   let lines = source.split("\n").map(fn(line) { line.to_string() }).collect()
   for line in lines {
     let trimmed = line.trim().to_string()
-    if !(trimmed.has_prefix("let ")) {
+    if !trimmed.has_prefix("let ") {
       continue
     }
     match trimmed.find(" = @dom.el(") {
       Some(index) => {
         let name = String::unsafe_substring(trimmed, start=4, end=index)
-        if !(temp_name_list_contains(names, name)) {
+        if !temp_name_list_contains(names, name) {
           names.push(name)
         }
       }

--- a/src/lsp/io.mbt
+++ b/src/lsp/io.mbt
@@ -77,7 +77,7 @@ pub fn filename_to_uri(filename : String) -> String {
 ///|
 /// Read a document by URI, ignoring unsupported non-file schemes.
 pub fn read_uri_text(uri : String) -> String? {
-  if uri.contains("://") && !(uri.has_prefix("file://")) {
+  if uri.contains("://") && !uri.has_prefix("file://") {
     None
   } else {
     read_file_text(uri_to_filename(uri))

--- a/src/lsp/io.mbt
+++ b/src/lsp/io.mbt
@@ -77,7 +77,7 @@ pub fn filename_to_uri(filename : String) -> String {
 ///|
 /// Read a document by URI, ignoring unsupported non-file schemes.
 pub fn read_uri_text(uri : String) -> String? {
-  if uri.contains("://") && not(uri.has_prefix("file://")) {
+  if uri.contains("://") && !(uri.has_prefix("file://")) {
     None
   } else {
     read_file_text(uri_to_filename(uri))

--- a/src/runtime/dom/dom.mbt
+++ b/src/runtime/dom/dom.mbt
@@ -446,7 +446,7 @@ pub fn[T] bindRef(ref_ : @vm.TemplateRef[T], target : @js.Any) -> Unit {
 /// Resolve a template ref, preferring the typed binding table before the named table.
 pub fn[T] resolve_template_ref(ref_ : @vm.TemplateRef[T]) -> T? {
   let bound_target = lookup_bound_template_ref(@js.any(ref_))
-  if not(@js.is_nullish(bound_target)) {
+  if !(@js.is_nullish(bound_target)) {
     return Some(bound_target.cast())
   }
   let named_target = lookup_template_ref(ref_.name())

--- a/src/runtime/dom/dom.mbt
+++ b/src/runtime/dom/dom.mbt
@@ -446,7 +446,7 @@ pub fn[T] bindRef(ref_ : @vm.TemplateRef[T], target : @js.Any) -> Unit {
 /// Resolve a template ref, preferring the typed binding table before the named table.
 pub fn[T] resolve_template_ref(ref_ : @vm.TemplateRef[T]) -> T? {
   let bound_target = lookup_bound_template_ref(@js.any(ref_))
-  if !(@js.is_nullish(bound_target)) {
+  if !@js.is_nullish(bound_target) {
     return Some(bound_target.cast())
   }
   let named_target = lookup_template_ref(ref_.name())

--- a/src/runtime/runtime.mbt
+++ b/src/runtime/runtime.mbt
@@ -289,7 +289,7 @@ fn scope_css_rules(css : String, scope_id : String) -> String {
           }
         }
       }
-      if not(scoped_selectors.is_empty()) {
+      if !(scoped_selectors.is_empty()) {
         scoped_chunks.push(
           wrap_css_block(scoped_selectors.join(", "), body.trim().to_string()),
         )
@@ -587,7 +587,7 @@ fn skip_css_comment(source : String, start : Int) -> Int {
 ///|
 /// Return whether an at-rule contains nested selectors that still need scoping.
 fn scopes_nested_css_rules(header : String) -> Bool {
-  not(
+  !(
     header.has_prefix("@keyframes") ||
     header.has_prefix("@-webkit-keyframes") ||
     header.has_prefix("@font-face") ||

--- a/src/runtime/runtime.mbt
+++ b/src/runtime/runtime.mbt
@@ -289,7 +289,7 @@ fn scope_css_rules(css : String, scope_id : String) -> String {
           }
         }
       }
-      if !(scoped_selectors.is_empty()) {
+      if !scoped_selectors.is_empty() {
         scoped_chunks.push(
           wrap_css_block(scoped_selectors.join(", "), body.trim().to_string()),
         )
@@ -587,13 +587,11 @@ fn skip_css_comment(source : String, start : Int) -> Int {
 ///|
 /// Return whether an at-rule contains nested selectors that still need scoping.
 fn scopes_nested_css_rules(header : String) -> Bool {
-  !(
-    header.has_prefix("@keyframes") ||
-    header.has_prefix("@-webkit-keyframes") ||
-    header.has_prefix("@font-face") ||
-    header.has_prefix("@page") ||
-    header.has_prefix("@property"),
-  )
+  !(header.has_prefix("@keyframes") ||
+  header.has_prefix("@-webkit-keyframes") ||
+  header.has_prefix("@font-face") ||
+  header.has_prefix("@page") ||
+  header.has_prefix("@property"))
 }
 
 ///|

--- a/src/tooling/lsp_completion.mbt
+++ b/src/tooling/lsp_completion.mbt
@@ -10,7 +10,7 @@ fn macro_completion_items(prefix : String) -> Array[ToolingCompletionItem] {
   ]
   let items : Array[ToolingCompletionItem] = []
   for entry in entries {
-    if prefix.length() > 0 && not(entry.0.has_prefix(prefix)) {
+    if prefix.length() > 0 && !(entry.0.has_prefix(prefix)) {
       continue
     }
     items.push({
@@ -42,7 +42,7 @@ fn directive_completion_items(prefix : String) -> Array[ToolingCompletionItem] {
   ]
   let items : Array[ToolingCompletionItem] = []
   for entry in entries {
-    if not(entry.0.has_prefix(prefix)) {
+    if !(entry.0.has_prefix(prefix)) {
       continue
     }
     items.push({
@@ -115,7 +115,7 @@ fn prefixed_completion_items(
 ) -> Array[ToolingCompletionItem] {
   let items : Array[ToolingCompletionItem] = []
   for entry in entries {
-    if not(entry.has_prefix(prefix)) {
+    if !(entry.has_prefix(prefix)) {
       continue
     }
     items.push({ label: entry, kind, detail, insert_text: entry })

--- a/src/tooling/lsp_completion.mbt
+++ b/src/tooling/lsp_completion.mbt
@@ -10,7 +10,7 @@ fn macro_completion_items(prefix : String) -> Array[ToolingCompletionItem] {
   ]
   let items : Array[ToolingCompletionItem] = []
   for entry in entries {
-    if prefix.length() > 0 && !(entry.0.has_prefix(prefix)) {
+    if prefix.length() > 0 && !entry.0.has_prefix(prefix) {
       continue
     }
     items.push({
@@ -42,7 +42,7 @@ fn directive_completion_items(prefix : String) -> Array[ToolingCompletionItem] {
   ]
   let items : Array[ToolingCompletionItem] = []
   for entry in entries {
-    if !(entry.0.has_prefix(prefix)) {
+    if !entry.0.has_prefix(prefix) {
       continue
     }
     items.push({
@@ -115,7 +115,7 @@ fn prefixed_completion_items(
 ) -> Array[ToolingCompletionItem] {
   let items : Array[ToolingCompletionItem] = []
   for entry in entries {
-    if !(entry.has_prefix(prefix)) {
+    if !entry.has_prefix(prefix) {
       continue
     }
     items.push({ label: entry, kind, detail, insert_text: entry })

--- a/src/tooling/lsp_index.mbt
+++ b/src/tooling/lsp_index.mbt
@@ -539,12 +539,12 @@ fn infer_component_template_ref_target(
   filename : String,
 ) -> (String, Array[@compiler.MacroField]) {
   for path in component_template_ref_candidate_paths(filename, tag) {
-    if !(@fs.path_exists(path)) {
+    if !@fs.path_exists(path) {
       continue
     }
     let source = @fs.read_file_to_string(path) catch { _ => continue }
     let doc = @compiler.parse_sfc(source, filename=path) catch { _ => continue }
-    if !(doc.expose.is_empty()) || doc.expose_binding is Some(_) {
+    if !doc.expose.is_empty() || doc.expose_binding is Some(_) {
       return (tag + " expose", doc.expose)
     }
     return ("component " + tag, [])

--- a/src/tooling/lsp_index.mbt
+++ b/src/tooling/lsp_index.mbt
@@ -539,12 +539,12 @@ fn infer_component_template_ref_target(
   filename : String,
 ) -> (String, Array[@compiler.MacroField]) {
   for path in component_template_ref_candidate_paths(filename, tag) {
-    if not(@fs.path_exists(path)) {
+    if !(@fs.path_exists(path)) {
       continue
     }
     let source = @fs.read_file_to_string(path) catch { _ => continue }
     let doc = @compiler.parse_sfc(source, filename=path) catch { _ => continue }
-    if not(doc.expose.is_empty()) || doc.expose_binding is Some(_) {
+    if !(doc.expose.is_empty()) || doc.expose_binding is Some(_) {
       return (tag + " expose", doc.expose)
     }
     return ("component " + tag, [])

--- a/src/tooling/lsp_index_scan.mbt
+++ b/src/tooling/lsp_index_scan.mbt
@@ -154,7 +154,7 @@ fn ToolingDocument::parse_resolved_template_ref_member_ref(
     None => return None
   }
   let binding_name = self.span_text(binding_span)
-  if not(ToolingDocument::identifier_literal(binding_name)) {
+  if !(ToolingDocument::identifier_literal(binding_name)) {
     return None
   }
   cursor = close_paren + 1
@@ -170,7 +170,7 @@ fn ToolingDocument::parse_resolved_template_ref_member_ref(
         (chars[cursor] == ' ' || chars[cursor] == '\t') {
     cursor += 1
   }
-  if cursor >= search_span.end || not(is_identifier_char(chars[cursor])) {
+  if cursor >= search_span.end || !(is_identifier_char(chars[cursor])) {
     return None
   }
   let member_start = cursor
@@ -259,7 +259,7 @@ fn ToolingDocument::identifier_literal(source : String) -> Bool {
     return false
   }
   for ch in source {
-    if not(is_identifier_char(ch)) {
+    if !(is_identifier_char(ch)) {
       return false
     }
   }
@@ -285,7 +285,7 @@ fn ToolingDocument::member_span_after_binding(
         (chars[cursor] == ' ' || chars[cursor] == '\t') {
     cursor += 1
   }
-  if cursor >= chars.length() || not(is_identifier_char(chars[cursor])) {
+  if cursor >= chars.length() || !(is_identifier_char(chars[cursor])) {
     return None
   }
   let start = cursor
@@ -476,10 +476,10 @@ fn ToolingDocument::find_token_in_span(
         break
       }
     }
-    let before_ok = cursor == 0 || not(is_identifier_char(chars[cursor - 1]))
+    let before_ok = cursor == 0 || !(is_identifier_char(chars[cursor - 1]))
     let end_ = cursor + token_chars.length()
     let after_ok = end_ >= chars.length() ||
-      not(is_identifier_char(chars[end_]))
+      !(is_identifier_char(chars[end_]))
     if matched && before_ok && after_ok {
       return Some({ start: cursor, end: end_ })
     }

--- a/src/tooling/lsp_index_scan.mbt
+++ b/src/tooling/lsp_index_scan.mbt
@@ -154,7 +154,7 @@ fn ToolingDocument::parse_resolved_template_ref_member_ref(
     None => return None
   }
   let binding_name = self.span_text(binding_span)
-  if !(ToolingDocument::identifier_literal(binding_name)) {
+  if !ToolingDocument::identifier_literal(binding_name) {
     return None
   }
   cursor = close_paren + 1
@@ -170,7 +170,7 @@ fn ToolingDocument::parse_resolved_template_ref_member_ref(
         (chars[cursor] == ' ' || chars[cursor] == '\t') {
     cursor += 1
   }
-  if cursor >= search_span.end || !(is_identifier_char(chars[cursor])) {
+  if cursor >= search_span.end || !is_identifier_char(chars[cursor]) {
     return None
   }
   let member_start = cursor
@@ -259,7 +259,7 @@ fn ToolingDocument::identifier_literal(source : String) -> Bool {
     return false
   }
   for ch in source {
-    if !(is_identifier_char(ch)) {
+    if !is_identifier_char(ch) {
       return false
     }
   }
@@ -285,7 +285,7 @@ fn ToolingDocument::member_span_after_binding(
         (chars[cursor] == ' ' || chars[cursor] == '\t') {
     cursor += 1
   }
-  if cursor >= chars.length() || !(is_identifier_char(chars[cursor])) {
+  if cursor >= chars.length() || !is_identifier_char(chars[cursor]) {
     return None
   }
   let start = cursor
@@ -476,10 +476,9 @@ fn ToolingDocument::find_token_in_span(
         break
       }
     }
-    let before_ok = cursor == 0 || !(is_identifier_char(chars[cursor - 1]))
+    let before_ok = cursor == 0 || !is_identifier_char(chars[cursor - 1])
     let end_ = cursor + token_chars.length()
-    let after_ok = end_ >= chars.length() ||
-      !(is_identifier_char(chars[end_]))
+    let after_ok = end_ >= chars.length() || !is_identifier_char(chars[end_])
     if matched && before_ok && after_ok {
       return Some({ start: cursor, end: end_ })
     }

--- a/src/tooling/lsp_queries.mbt
+++ b/src/tooling/lsp_queries.mbt
@@ -156,7 +156,7 @@ fn ToolingQuery::resolved_template_ref_completion_items(
           continue
         }
         for field in binding.fields {
-          if !(field.name.has_prefix(prefix)) {
+          if !field.name.has_prefix(prefix) {
             continue
           }
           items.push({
@@ -209,7 +209,7 @@ fn ToolingQuery::resolved_template_ref_completion_context(
     None => return None
   }
   let binding_name = document.span_text(arg_span)
-  if !(ToolingDocument::identifier_literal(binding_name)) {
+  if !ToolingDocument::identifier_literal(binding_name) {
     return None
   }
   cursor = open_paren
@@ -231,7 +231,7 @@ fn ToolingQuery::resolved_template_ref_completion_context(
     start=name_start,
     end=name_end,
   )
-  if !(callee.has_suffix("resolve_template_ref")) {
+  if !callee.has_suffix("resolve_template_ref") {
     return None
   }
   Some((binding_name, prefix))
@@ -342,7 +342,7 @@ fn ToolingQuery::member_completion_items(
           continue
         }
         for field in binding.fields {
-          if !(field.name.has_prefix(prefix)) {
+          if !field.name.has_prefix(prefix) {
             continue
           }
           items.push({

--- a/src/tooling/lsp_queries.mbt
+++ b/src/tooling/lsp_queries.mbt
@@ -156,7 +156,7 @@ fn ToolingQuery::resolved_template_ref_completion_items(
           continue
         }
         for field in binding.fields {
-          if not(field.name.has_prefix(prefix)) {
+          if !(field.name.has_prefix(prefix)) {
             continue
           }
           items.push({
@@ -209,7 +209,7 @@ fn ToolingQuery::resolved_template_ref_completion_context(
     None => return None
   }
   let binding_name = document.span_text(arg_span)
-  if not(ToolingDocument::identifier_literal(binding_name)) {
+  if !(ToolingDocument::identifier_literal(binding_name)) {
     return None
   }
   cursor = open_paren
@@ -231,7 +231,7 @@ fn ToolingQuery::resolved_template_ref_completion_context(
     start=name_start,
     end=name_end,
   )
-  if not(callee.has_suffix("resolve_template_ref")) {
+  if !(callee.has_suffix("resolve_template_ref")) {
     return None
   }
   Some((binding_name, prefix))
@@ -342,7 +342,7 @@ fn ToolingQuery::member_completion_items(
           continue
         }
         for field in binding.fields {
-          if not(field.name.has_prefix(prefix)) {
+          if !(field.name.has_prefix(prefix)) {
             continue
           }
           items.push({

--- a/src/tooling/lsp_support.mbt
+++ b/src/tooling/lsp_support.mbt
@@ -146,7 +146,7 @@ fn ToolingDocument::current_token_prefix(
   let chars = self.chars
   let limit = if offset < chars.length() { offset } else { chars.length() }
   let mut start = limit
-  while start > 0 && not(token_boundary(chars[start - 1])) {
+  while start > 0 && !(token_boundary(chars[start - 1])) {
     start -= 1
   }
   String::unsafe_substring(self.source, start~, end=limit)

--- a/src/tooling/lsp_support.mbt
+++ b/src/tooling/lsp_support.mbt
@@ -146,7 +146,7 @@ fn ToolingDocument::current_token_prefix(
   let chars = self.chars
   let limit = if offset < chars.length() { offset } else { chars.length() }
   let mut start = limit
-  while start > 0 && !(token_boundary(chars[start - 1])) {
+  while start > 0 && !token_boundary(chars[start - 1]) {
     start -= 1
   }
   String::unsafe_substring(self.source, start~, end=limit)


### PR DESCRIPTION
## Summary

Part 1 of [#53](https://github.com/ubugeeei/vapor-moon/issues/53)
(\"eliminate remaining MoonBit 0.9 deprecation warnings\"). Mechanical
replacement of 116 \`not(expr)\` prelude calls with \`!expr\` everywhere
under \`src/\`.

Per the original issue text, this cleanup is intentionally landing as a
separate PR from the production-readiness work (PR #89) so the
mechanical replacements stay easy to review.

## What this does

- One sed-style pattern: \`not( -> !( \` (keeping the existing close
  paren). Always wrapping as \`!(expr)\` preserves operator precedence
  with no edge cases.
- 116 sites across 37 files: compiler / runtime / tooling / lsp / cli.
- No behavior change. All 11 native tests pass locally and pre-commit
  hook (\`moon fmt\`, \`moon check\`, \`moon test\`) is clean.

## What this does *not* do

The other two deprecation classes called out in #53 are deferred to
follow-up commits in this same PR (or a separate PR if review prefers
that):

- \`derive(Show)\` (41 sites). Coupled with \`.to_string()\` /
  \`inspect()\` snapshot output: swapping to \`derive(Debug)\` would
  change the snapshot text. Needs a per-type decision (auto-derive
  Debug for AST types vs. manual \`impl Show\` for error types) so it
  is not really mechanical.
- \`err.to_string()\` (13 sites). Same coupling — depends on what Show
  vs. Debug each error type gets.

I can do those in this PR if you'd rather have a single mega-cleanup,
but they're meaningfully riskier and noisier than this change.

## Test plan

- [x] \`moon test\` (native) — 11/11 pass locally.
- [x] Pre-commit hook (moon fmt + check + tests) is clean.
- [ ] CI: native ubuntu, native macos, js, e2e, editor-integrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)