### PR TITLE
feat(runtime): provide / inject Phase 1 context registry (#14)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,7 @@ jobs:
       - name: Runtime JS tests
         run: |
           moon test --target js src/runtime
+          moon test --target js src/runtime/context
           moon test --target js src/runtime/dom
           moon test --target js src/runtime/server
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,31 @@ let props : Props = defineProps({
 - runtime declaration literals are intentionally unsupported
 - `useId()` and `useTemplateRef("name")` are supported inside setup scope
 
+## Provide / Inject (Phase 1)
+
+Vapor Moon ships a minimal `provide` / `inject` registry for app-wide
+singletons like theme, locale, or a router handle. Phase 1 lives in
+`src/runtime/context/` and is intentionally flat — every `provide`
+overwrites the previous value for that key within the JS realm, and
+`inject` returns the most recently provided value.
+
+```moonbit
+import {
+  "ubugeeei/vapor_moon/src/runtime/context" @context,
+}
+
+let theme = @context.provide("theme", "dark")
+let resolved : String? = @context.inject("theme")
+let with_default = @context.inject_or("locale", "en")
+```
+
+True ancestor scoping — where a `provide` is only visible to descendant
+components — requires a scope stack with `push_scope` / `pop_scope`
+lifecycle calls that the compiler wraps around each generated
+`render_dom` / `render_ssr`. That work is tracked in
+[#14](https://github.com/ubugeeei/vapor-moon/issues/14). Until Phase 2
+lands, use `provide` only for values that are logically singletons.
+
 ## Generic Components
 
 Vue-style generic declarations are supported on `<script>`:

--- a/src/runtime/context/context.mbt
+++ b/src/runtime/context/context.mbt
@@ -1,0 +1,101 @@
+///|
+/// Provide / inject — Phase 1.
+///
+/// This module exposes the API surface that the Vue 3-style `provide` /
+/// `inject` pattern lowers to. The naming and semantics are designed to
+/// match what generated `.client.mbt` code can call directly:
+///
+/// ```mbt
+/// // inside a <script> block:
+/// let theme = @context.provide("theme", "dark")
+/// let theme = @context.inject("theme")
+/// ```
+///
+/// Scope contract (read carefully)
+/// -------------------------------
+/// Phase 1 is intentionally **flat / global** within one JS realm. There
+/// is exactly one context registry per page; `provide` overwrites the
+/// previous value for the same key, and `inject` returns the most
+/// recently provided value (or `None`).
+///
+/// True ancestor scoping — where one component's `provide` is only
+/// visible to its descendants and not to siblings — requires:
+/// 1. A scope stack with `push_scope` / `pop_scope` lifecycle calls;
+/// 2. The compiler wrapping each generated `render_dom` / `render_ssr`
+///    body in those calls.
+///
+/// That work is tracked in
+/// <https://github.com/ubugeeei/vapor-moon/issues/14>. The
+/// Phase 1 API is shaped so that the Phase 2 swap-in stays
+/// backwards-compatible: existing call sites do not change, only the
+/// underlying lookup gains scope awareness.
+///
+/// Until Phase 2 lands, do not rely on `provide` for component-private
+/// state. Use it for app-wide singletons (theme, locale, router).
+
+///|
+extern "js" fn context_store_set(key : String, value : @js.Any) -> Unit =
+  #| (key, value) => {
+  #|   const store = (globalThis.__vaporMoonContext ??= new Map());
+  #|   store.set(key, value);
+  #| }
+
+///|
+extern "js" fn context_store_get(key : String) -> @js.Any =
+  #| (key) => {
+  #|   const store = (globalThis.__vaporMoonContext ??= new Map());
+  #|   return store.has(key) ? store.get(key) : undefined;
+  #| }
+
+///|
+extern "js" fn context_store_has(key : String) -> Bool =
+  #| (key) => {
+  #|   const store = (globalThis.__vaporMoonContext ??= new Map());
+  #|   return store.has(key);
+  #| }
+
+///|
+extern "js" fn context_store_clear() -> Unit =
+  #| () => {
+  #|   const store = (globalThis.__vaporMoonContext ??= new Map());
+  #|   store.clear();
+  #| }
+
+///|
+/// Register a value for `key`. The value flows through the JS-side
+/// global context map; consumers retrieve it via `inject`.
+///
+/// Returns the value back unchanged so call sites can write
+/// `let theme = provide("theme", "dark")` idiomatically.
+pub fn[T] provide(key : String, value : T) -> T {
+  context_store_set(key, @js.any(value))
+  value
+}
+
+///|
+/// Look up the value previously provided for `key`, returning `None` if
+/// no `provide` has been called for that key in the current realm.
+pub fn[T] inject(key : String) -> T? {
+  if context_store_has(key) {
+    Some(context_store_get(key).cast())
+  } else {
+    None
+  }
+}
+
+///|
+/// Look up the value for `key`, falling back to `default_value` when no
+/// `provide` has been called.
+pub fn[T] inject_or(key : String, default_value : T) -> T {
+  match inject(key) {
+    Some(value) => value
+    None => default_value
+  }
+}
+
+///|
+/// Test helper — empty the registry. Production code should not need
+/// this; it exists so unit tests can run in isolation.
+pub fn reset_for_tests() -> Unit {
+  context_store_clear()
+}

--- a/src/runtime/context/context_test.mbt
+++ b/src/runtime/context/context_test.mbt
@@ -1,0 +1,48 @@
+///|
+test "provide stores and returns the value unchanged" {
+  reset_for_tests()
+  let returned = provide("theme", "dark")
+  assert_eq(returned, "dark")
+}
+
+///|
+test "inject returns Some for a previously provided key" {
+  reset_for_tests()
+  ignore(provide("locale", "ja"))
+  let value : String? = inject("locale")
+  assert_eq(value, Some("ja"))
+}
+
+///|
+test "inject returns None for an unknown key" {
+  reset_for_tests()
+  let value : String? = inject("nonexistent")
+  assert_eq(value, None)
+}
+
+///|
+test "inject_or falls back to the default when nothing was provided" {
+  reset_for_tests()
+  let value = inject_or("missing", "fallback")
+  assert_eq(value, "fallback")
+}
+
+///|
+test "provide overwrites a previous value for the same key (Phase 1 flat scope)" {
+  reset_for_tests()
+  ignore(provide("counter", 1))
+  ignore(provide("counter", 2))
+  let value : Int? = inject("counter")
+  assert_eq(value, Some(2))
+}
+
+///|
+test "different keys do not collide" {
+  reset_for_tests()
+  ignore(provide("a", 1))
+  ignore(provide("b", 2))
+  let a : Int? = inject("a")
+  let b : Int? = inject("b")
+  assert_eq(a, Some(1))
+  assert_eq(b, Some(2))
+}

--- a/src/runtime/context/moon.pkg
+++ b/src/runtime/context/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "mizchi/js/core" @js,
+}
+
+supported_targets = "js"


### PR DESCRIPTION
## Summary

Phase 1 of [#14](https://github.com/ubugeeei/vapor-moon/issues/14). Adds the API surface that Vue-style \`provide\` / \`inject\` lowers to, backed by a flat JS-realm-wide registry.

The API shape — \`provide\`, \`inject\`, \`inject_or\`, \`reset_for_tests\` — is what the Phase 2 scoped implementation will keep using, so call sites do not need to change when the scope stack lands.

\`\`\`mbt
import { "ubugeeei/vapor_moon/src/runtime/context" @context }

let theme = @context.provide("theme", "dark")
let resolved : String? = @context.inject("theme")
let with_default = @context.inject_or("locale", "en")
\`\`\`

## What's intentionally not in this PR

Per-component scoping. Phase 1 is **flat**: every \`provide\` overwrites the previous value for that key within the JS realm. True ancestor scoping requires:

1. A scope stack with \`push_scope\` / \`pop_scope\`.
2. The compiler wrapping each generated \`render_dom\` / \`render_ssr\` body in those calls.

That work is the Phase 2 entry point on [#14](https://github.com/ubugeeei/vapor-moon/issues/14). Until then, use \`provide\` only for values that are logically singletons (theme, locale, router).

## Test plan

- [x] \`moon test --target js src/runtime/context\` — 6 unit tests cover provide/inject/inject_or, default fallback, overwrite, key isolation.
- [x] CI workflow updated to run the new test package.
- [ ] CI: check-js (will run the new package).

## Docs

- README gains a "Provide / Inject (Phase 1)" section that documents the limitation and links to the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)