### PR TITLE
ci(automation): harden dependabot, add stale bot and PR auto-labeler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,17 @@
 version: 2
+
+# Conventions
+# - All four ecosystems are grouped so each Monday produces at most one
+#   PR per package set instead of one PR per dependency.
+# - `dependencies` label is the GitHub standard; `codex` keeps the
+#   project's existing filter working.
+# - open-pull-requests-limit caps the active queue so Monday batches
+#   don't pile up indefinitely if a previous week's PR is still in
+#   review.
+# - Major version bumps are ignored by default — they almost always need
+#   a code change in the same PR, which Dependabot can't author. Bump
+#   majors by editing the lockfile manually and dropping the ignore.
+
 updates:
   - package-ecosystem: github-actions
     directory: /
@@ -9,10 +22,16 @@ updates:
       timezone: Asia/Tokyo
     labels:
       - codex
+      - dependencies
+      - github-actions
+    open-pull-requests-limit: 5
     groups:
       github-actions:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: npm
     directory: /e2e
@@ -23,10 +42,16 @@ updates:
       timezone: Asia/Tokyo
     labels:
       - codex
+      - dependencies
+      - javascript
+    open-pull-requests-limit: 5
     groups:
       e2e-node:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: npm
     directory: /editors/vscode
@@ -37,10 +62,17 @@ updates:
       timezone: Asia/Tokyo
     labels:
       - codex
+      - dependencies
+      - javascript
+      - editor
+    open-pull-requests-limit: 5
     groups:
       vscode-node:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: cargo
     directory: /editors/zed
@@ -51,7 +83,14 @@ updates:
       timezone: Asia/Tokyo
     labels:
       - codex
+      - dependencies
+      - rust
+      - editor
+    open-pull-requests-limit: 5
     groups:
       zed-rust:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,62 @@
+# Path-based auto-labels applied by .github/workflows/labeler.yaml.
+# Each label name maps to a list of glob predicates; the action assigns
+# the label whenever a PR touches at least one matching path.
+
+compiler:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/compiler/**"
+
+runtime:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/runtime/**"
+
+lsp:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/lsp/**"
+          - "src/tooling/lsp_**"
+          - "src/cmd/vapor_moon_lsp/**"
+
+tooling:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/tooling/**"
+
+cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/cmd/vapor_moon/**"
+          - "src/cmd/vapor_moon_cli/**"
+
+editor:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "editors/**"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/actions/**"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*_test.mbt"
+          - "e2e/**"
+          - "scripts/smoke_*.sh"
+
+release:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/release.yaml"
+          - "CHANGELOG.md"
+          - "moon.mod.json"

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,19 @@
+name: Auto-label PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,47 @@
+name: Stale issues and pull requests
+
+on:
+  schedule:
+    # Run once a day at 03:00 JST (18:00 UTC the previous day).
+    - cron: "0 18 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  pull-requests: write
+
+# Tunable knobs — kept generous so genuine open work doesn't get nuked.
+# Anything labeled `production-readiness`, `security`, or `pinned` is
+# never marked stale (those represent intentional follow-ups).
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+          stale-issue-label: stale
+          stale-issue-message: >
+            This issue has had no activity for 90 days. It will be closed in
+            30 days if no further activity occurs. If it is still relevant,
+            drop a comment to keep it open.
+          close-issue-message: >
+            Closing as stale. Reopen with a fresh comment if it's still
+            relevant — no offense intended; we just don't want the tracker
+            to drift.
+          exempt-issue-labels: "pinned,production-readiness,security,roadmap"
+
+          days-before-pr-stale: 45
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          stale-pr-message: >
+            This pull request has had no activity for 45 days. It will be
+            closed in 14 days unless someone pushes a commit or comments.
+          close-pr-message: >
+            Closing as stale. Push a fresh commit or comment to reopen.
+          exempt-pr-labels: "pinned,security,wip,blocked"
+
+          operations-per-run: 100
+          ascending: true


### PR DESCRIPTION
## Summary

Three automation chores bundled into one PR:

### 1. Dependabot hardening (\`.github/dependabot.yml\`)
- Each ecosystem's open PR queue is capped at \`5\` so Monday batches
  can't pile up if a previous week's PR is still in review.
- Ignore semver-major bumps by default; majors usually need a code
  change in the same PR that Dependabot can't author.
- Add the standard \`dependencies\` label alongside the project's
  \`codex\` filter, plus ecosystem flavors (\`github-actions\`,
  \`javascript\`, \`rust\`, \`editor\`) so triage queues read easily.

### 2. Stale issue / PR bot (\`.github/workflows/stale.yaml\`)
- Daily run at 03:00 JST.
- Issues: stale after 90 days, close after another 30.
- PRs: stale after 45 days, close after another 14.
- Exempt labels for genuine open work: \`pinned\`,
  \`production-readiness\`, \`security\`, \`roadmap\` on issues;
  \`pinned\`, \`security\`, \`wip\`, \`blocked\` on PRs.

### 3. PR auto-labeler (\`.github/labeler.yml\` + workflow)
- Path-based auto-labeling so every PR gets the right area tag:
  \`compiler\`, \`runtime\`, \`lsp\`, \`tooling\`, \`cli\`,
  \`editor\`, \`ci\`, \`documentation\`, \`tests\`, \`release\`.
- Uses \`pull_request_target\` with \`sync-labels: true\` so labels
  track the current diff (drop when paths stop being touched).

## Test plan

- [x] YAML syntax round-trips through the workflow files.
- [ ] CI: green (these workflows don't run on PRs themselves until
      merged, but check the YAML parses).
- [ ] After merge: confirm the labeler fires on the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)