### PR TITLE
ci(setup-moonbit): always print archive SHA-256 as workflow notice (#83)

### DIFF
--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -38,17 +38,22 @@ runs:
           *) echo "Unsupported platform: $(uname -ms)" >&2; exit 1 ;;
         esac
 
+        # Compute the SHA-256 of `file` and either verify it against
+        # `expected` (when set) or just surface it as a workflow notice
+        # so the matrix leg's logs can be used to pin a new platform's
+        # checksum (see #83 Phase 2 follow-up).
         verify_sha256() {
           local file="$1"
           local expected="$2"
-          if [[ -z "$expected" ]]; then
-            return 0
-          fi
           local actual
           if command -v sha256sum >/dev/null 2>&1; then
             actual="$(sha256sum "$file" | awk '{print $1}')"
           else
             actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+          fi
+          echo "::notice file=action.yml,title=SHA-256::$(basename "$file")=$actual"
+          if [[ -z "$expected" ]]; then
+            return 0
           fi
           if [[ "$actual" != "$expected" ]]; then
             echo "SHA-256 mismatch for $file: expected $expected, got $actual" >&2


### PR DESCRIPTION
## Summary

Small improvement to the \`setup-moonbit\` composite action so the next
time we want to pin a new platform's checksum (issue #83 Phase 2 covers
the macOS leg) we can read the value straight out of the CI logs
instead of having to re-derive it locally on a Mac.

\`verify_sha256()\` now always computes the actual SHA-256 and surfaces
it via a GitHub \`::notice::\` annotation, regardless of whether an
\`expected\` value was passed. When \`expected\` is set, behavior is
unchanged: mismatch still fails the action.

## Why this is safe

- No behavior change on the pinned path (ubuntu): the comparison still
  runs and the action still exits on mismatch.
- On the unpinned macOS path: the action used to silently return; now
  it prints the SHA before returning, which is information leakage
  only — the value is already public on cli.moonbitlang.com.

## Next step (separate PR)

After this lands, read the macOS notices off the next \`check-native
(macos-latest)\` run and pin them into ci.yaml's matrix.

## Test plan

- [x] YAML still parses.
- [ ] CI: green. The notice annotation will appear on the macOS leg's
      job summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)