### PR TITLE
ci(release): add release-drafter and FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# GitHub Sponsors button targets.
+github: [ubugeeei, mizchi]

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,70 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "🚀 Features"
+    labels:
+      - feature
+      - feat
+      - enhancement
+  - title: "🐛 Fixes"
+    labels:
+      - fix
+      - bugfix
+      - bug
+  - title: "🔒 Security"
+    labels:
+      - security
+  - title: "🧰 Maintenance"
+    labels:
+      - chore
+      - refactor
+      - style
+  - title: "📚 Documentation"
+    labels:
+      - documentation
+      - docs
+  - title: "⚙️ CI / Infrastructure"
+    labels:
+      - ci
+      - infrastructure
+  - title: "🧪 Tests"
+    labels:
+      - tests
+      - test
+  - title: "📦 Dependencies"
+    labels:
+      - dependencies
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - breaking
+  minor:
+    labels:
+      - feature
+      - feat
+      - enhancement
+  patch:
+    labels:
+      - fix
+      - bugfix
+      - bug
+      - chore
+      - documentation
+      - docs
+      - ci
+      - tests
+  default: patch
+
+template: |
+  ## Highlights
+
+  $CHANGES
+
+  ## Full Changelog
+
+  https://github.com/ubugeeei/vapor-moon/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,11 +1,13 @@
 name: Release Drafter
 
+# release-drafter requires its config file to live on the default
+# branch — running on pull_request before merge causes "Invalid config
+# file" failures. Trigger only on push to main and on demand.
 on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
+  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Two low-touch additions that pay off at release time and on the repo
landing page.

### \`release-drafter.yml\` + workflow
Auto-drafts a GitHub Release for the next tag. PRs are bucketed by
label:

| Section | Labels |
|---|---|
| Features | feature, feat, enhancement |
| Fixes | fix, bugfix, bug |
| Security | security |
| Maintenance | chore, refactor, style |
| Documentation | documentation, docs |
| CI / Infrastructure | ci, infrastructure |
| Tests | tests, test |
| Dependencies | dependencies |

Version resolves from labels:
- \`breaking\` → major bump
- \`feature\`/\`feat\`/\`enhancement\` → minor
- everything else → patch (default)

Composes with the existing \`release.yaml\` — drafter only prepares the
release body; tagging and the publish steps stay in the release
workflow.

### \`FUNDING.yml\`
Lights the "Sponsor" button on the repo page, pointing at \`ubugeeei\`
and \`mizchi\`.

## Test plan

- [x] YAML parses.
- [ ] CI: green (these workflows don't run on PRs themselves; verify
      after merge by opening a quick PR or checking the drafter run on
      the next push to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)