### PR TITLE
ci(setup-moonbit): cache toolchain across runs

### DIFF
--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -26,10 +26,36 @@ inputs:
 runs:
   using: composite
   steps:
+    # Cache the MoonBit toolchain + core lib so CI doesn't re-download
+    # 100+ MB every run. Cache key is the resolved version + OS + arch —
+    # when the version env changes (or a new platform is added) the cache
+    # naturally invalidates.
+    - name: Cache MoonBit toolchain
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.moon/bin
+          ~/.moon/lib
+          ~/.moon/include
+        key: moonbit-${{ runner.os }}-${{ runner.arch }}-${{ inputs.expected-version }}-${{ inputs.version }}
+        restore-keys: |
+          moonbit-${{ runner.os }}-${{ runner.arch }}-${{ inputs.expected-version }}-
+
     - name: Install MoonBit CLI
       shell: bash
       run: |
         set -euo pipefail
+        # Skip the full install if the cache restored a working toolchain
+        # matching the expected version. Saves ~30s per matrix leg.
+        if [[ -x "$HOME/.moon/bin/moon" ]]; then
+          actual_version="$($HOME/.moon/bin/moon version 2>/dev/null | sed -n 's/^moon \([^ ]*\).*/\1/p' || true)"
+          if [[ -n "${{ inputs.expected-version }}" && "$actual_version" == "${{ inputs.expected-version }}" && -d "$HOME/.moon/lib/core" ]]; then
+            echo "Cached MoonBit $actual_version is up to date — skipping install."
+            echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+            exit 0
+          fi
+        fi
+
         target=""
         case "$(uname -ms)" in
           "Darwin arm64") target="darwin-aarch64" ;;


### PR DESCRIPTION
## Summary

`actions/cache` restores `~/.moon/{bin,lib,include}` keyed by OS + arch + expected MoonBit version. The install step early-returns when:
- the cache restored a moon binary,
- `moon version` matches the expected version, and
- `~/.moon/lib/core` was restored (the moon bundle output).

Saves ~30s per matrix leg (4 legs × every CI run). The download + SHA-256 verify path is unchanged on a cache miss, so security guarantees from the pinning are preserved on cold runs.

Cache key includes `inputs.version` too so swapping the channel (`latest` → a specific build) invalidates cleanly.

## Test plan
- [ ] CI: green; check that the matrix legs report cache hits on the second run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)