### PR TITLE
chore: add SUPPORT.md and weekly security-audit workflow

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,33 @@
+# Getting help
+
+Thanks for using Vapor Moon. The fastest path depends on what you need.
+
+## Questions, design discussions, "how do I"
+Open a [GitHub Discussion](https://github.com/ubugeeei/vapor-moon/discussions).
+Free-form prose is welcome — please link the relevant `.mbtv` snippet or
+generated client/server output when possible.
+
+## Bug reports
+File a [Bug report issue](https://github.com/ubugeeei/vapor-moon/issues/new?template=bug_report.yml).
+The form will ask for a minimal reproduction, expected vs. actual
+behavior, and your MoonBit / Vapor Moon versions — please fill all
+required fields. Small repros are typically resolved within a few days;
+ten-line snippets land bug fixes faster than ten-file ones.
+
+## Feature requests
+Skim the [README "Status" section](../README.md#status) first to confirm
+the feature isn't already either shipped or intentionally out of scope.
+If you still want it, open a [Feature request issue](https://github.com/ubugeeei/vapor-moon/issues/new?template=feature_request.yml)
+with a concrete use case.
+
+## Security
+**Do not** open a public issue for security disclosures. Follow the
+process in [SECURITY.md](../SECURITY.md) — typically a private
+GitHub Security Advisory.
+
+## Editor / LSP problems
+Editor integration bugs are still bug reports, but please include:
+- Editor + version (e.g. `VS Code 1.96.0`),
+- The output of `vapor-moon --version`,
+- The LSP launcher trace (set `vaporMoon.languageServer.traceLevel` to
+  `verbose` in VS Code's settings, then reproduce).

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -1,0 +1,63 @@
+name: Security audit
+
+on:
+  schedule:
+    # Weekly on Tuesday 04:00 JST (Monday 19:00 UTC) so Dependabot's
+    # Monday batch has already opened any urgent PRs.
+    - cron: "0 19 * * 1"
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "editors/vscode/package*.json"
+      - "editors/zed/Cargo.*"
+      - "e2e/package*.json"
+      - "e2e/pnpm-lock.yaml"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  npm-audit-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - uses: pnpm/action-setup@v6
+        with:
+          version: "10"
+      - name: pnpm audit (e2e)
+        working-directory: e2e
+        # `--prod` because dev-only advisories (testing libs) are noisy
+        # and don't ship to users.
+        run: pnpm audit --prod --audit-level=high
+
+  npm-audit-vscode:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - name: npm audit (editors/vscode)
+        working-directory: editors/vscode
+        run: npm audit --audit-level=high
+
+  cargo-audit-zed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: cargo install --locked cargo-audit
+      - name: cargo audit (editors/zed)
+        working-directory: editors/zed
+        run: cargo audit --deny warnings


### PR DESCRIPTION
## Summary

### `.github/SUPPORT.md`
Surfaces the right venue for each kind of ask: Discussions for questions / design, bug-report YAML form for defects (filled minimal repro required), feature-request form for proposals, SECURITY.md for security disclosures, plus a note for editor / LSP problems asking for editor version + LSP trace.

### `.github/workflows/security-audit.yaml`
Three parallel jobs:
- `pnpm audit --prod --audit-level=high` for `e2e`.
- `npm audit --audit-level=high` for `editors/vscode`.
- `cargo audit --deny warnings` for `editors/zed`.

Schedule: every Tuesday 04:00 JST (after Dependabot's Monday batch), on workflow_dispatch, and on PRs that touch the relevant lockfiles.

## Test plan
- [x] YAML parses.
- [ ] CI: green (the security-audit workflow itself runs only on the schedule + manual / lockfile PRs).
- [ ] After merge: run `gh workflow run security-audit.yaml` to smoke-test the three audit commands against the current lockfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)