### PR TITLE
chore(release): cut v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ backwards compatible.
 
 ## [Unreleased]
 
+_Nothing yet — the next change starts here._
+
+## [0.2.0] — 2026-05-19
+
 ### Added
 - `vapor-moon --help` / `-h` / `help` and `vapor-moon --version` / `-V` flags
   (#80). The version string is sourced from a single `VERSION` constant shared
@@ -95,6 +99,7 @@ backwards compatible.
   server (luna SSR) code generation, scoped style hashing, basic editor
   tooling.
 
-[Unreleased]: https://github.com/ubugeeei/vapor-moon/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/ubugeeei/vapor-moon/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/ubugeeei/vapor-moon/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/ubugeeei/vapor-moon/releases/tag/v0.1.1
 [0.1.0]: https://github.com/ubugeeei/vapor-moon/releases/tag/v0.1.0

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vapor-moon",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vapor-moon",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vapor-moon",
   "displayName": "Vapor Moon",
   "description": "Language support and LSP client for Vapor Moon .mbtv components.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publisher": "ubugeeei",
   "license": "MIT",
   "author": {

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "zed_vapor_moon"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zed_vapor_moon"
 # Keep in sync with editors/zed/extension.toml and moon.mod.json.
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "vapor-moon"
 name = "Vapor Moon"
 description = "Vapor Moon support for .mbtv Single File Components."
-version = "0.1.1"
+version = "0.2.0"
 schema_version = 1
 authors = ["Ubugeeei <ubugeeei@gmail.com>"]
 repository = "https://github.com/ubugeeei/vapor-moon"

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "ubugeeei/vapor_moon",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "deps": {
     "mizchi/js": "0.10.17",
     "mizchi/luna": "0.23.0",

--- a/src/compiler/common/version.mbt
+++ b/src/compiler/common/version.mbt
@@ -4,4 +4,4 @@
 ///
 /// Keep this constant in sync with the `version` field of `moon.mod.json` at
 /// the repository root. `scripts/smoke_cli.sh` enforces the invariant in CI.
-pub const VERSION : String = "0.1.1"
+pub const VERSION : String = "0.2.0"


### PR DESCRIPTION
## Summary

Pre-1.0 minor release picking up the production-readiness sweep that landed since v0.1.1 (#89 → #101) plus the Nix / Vite+ tooling migration (#111–#120).

### Version bumps (in lock-step)
- `moon.mod.json`: `0.1.1 → 0.2.0`
- `src/compiler/common/version.mbt` `VERSION` constant: `0.1.1 → 0.2.0`
- `editors/vscode/package.json` + `package-lock.json`: `0.1.1 → 0.2.0`
- `editors/zed/extension.toml` + `Cargo.toml` + `Cargo.lock`: `0.1.1 → 0.2.0`

### CHANGELOG
- `[Unreleased]` reset to an empty placeholder so the next change starts a fresh section.
- Prior `[Unreleased]` body renamed to `[0.2.0] — 2026-05-19`.
- Link footnotes updated to `compare/v0.1.1...v0.2.0`.

### Highlights for v0.2.0
See `CHANGELOG.md [0.2.0]` for the full list. Headline items:

- 13 production-readiness issues shipped (#62 / #64 / #65 / #66 / #80–#88) plus the cross-platform CI matrix and Marketplace publish workflow.
- provide / inject Phase 1 runtime registry (#14).
- v-model on `<select multiple>` (#64) and final policy on file input v-model (#65).
- Tooling migration toward Nix (flake + devShell + CI gate + devcontainer) and Vite+ (scaffolded `@vapor-moon/vite-plugin` + `examples/vite-app`).
- Repo hygiene: ARCHITECTURE.md, CITATION.cff, .editorconfig, CODEOWNERS, FUNDING, YAML issue forms, stale bot, labeler, release-drafter, security-audit cron.

## After merge

1. Tag `v0.2.0` on `main` — the existing `release.yaml` job picks it up, dry-runs `moon publish`, packages the VS Code extension and (when `VSCE_PAT` is set) publishes to the Marketplace.
2. `release-drafter` resets its draft once the v0.2.0 tag exists; future PR labels start aggregating into the v0.3.0 draft.

## Test plan
- [x] `editor-integrations` CI: version-sync check passes (every file moved together).
- [x] Pre-commit hook clean.
- [ ] CI: green across all legs.
- [ ] After tag: confirm `release.yaml` runs successfully and the GitHub Release body matches the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)