### PR TITLE
ci(release): gate publish on CHANGELOG having the tagged version (#122)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Verify CHANGELOG section for tagged version
+        run: bash scripts/verify_changelog_section.sh
       - name: Setup MoonBit
         uses: ./.github/actions/setup-moonbit
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,16 @@ When opening a PR, make sure:
      `zed_vapor_moon` entry in `editors/zed/Cargo.lock`.
 2. Update `CHANGELOG.md`: rename the `[Unreleased]` section to the new
    version + date and add a fresh `[Unreleased]` block.
-3. Tag `vX.Y.Z` on `main`. The `Release Verify` workflow runs the
-   compiler dry-run publish (`moon publish --dry-run`) and packages /
-   uploads / publishes the VS Code extension when `VSCE_PAT` is
-   configured.
+3. Tag `vX.Y.Z` on `main`. The `Release Verify` workflow first runs
+   `scripts/verify_changelog_section.sh` (which fails if `CHANGELOG.md`
+   has no `## [X.Y.Z]` section, if `[Unreleased]` is still populated,
+   or if the tag name does not match the in-repo version). After that
+   gate it runs the compiler dry-run publish (`moon publish --dry-run`)
+   and packages / uploads / publishes the VS Code extension when
+   `VSCE_PAT` is configured.
+
+   You can run the changelog gate locally before tagging:
+
+   ```bash
+   bash scripts/verify_changelog_section.sh
+   ```

--- a/scripts/verify_changelog_section.sh
+++ b/scripts/verify_changelog_section.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Verify that CHANGELOG.md contains a section for the version currently
+# declared in moon.mod.json before letting a release proceed.
+#
+# Failure modes (each exits non-zero with a pointed message):
+#   - moon.mod.json version unreadable.
+#   - CHANGELOG.md has no `## [x.y.z] — …` section for the current
+#     version.
+#   - When GITHUB_REF_NAME is set (CI tag push), the tag does not match
+#     `v$VERSION` — caller probably forgot to bump moon.mod.json or
+#     tagged the wrong commit.
+#   - The [Unreleased] section is non-empty (i.e. still pointing at the
+#     would-be-released body). Tagging would orphan those entries.
+#
+# Run locally via `bash scripts/verify_changelog_section.sh`.
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+cd "$ROOT"
+
+version="$(grep -m1 '"version"' moon.mod.json | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+if [ -z "$version" ]; then
+  echo "verify_changelog_section: could not read version from moon.mod.json" >&2
+  exit 1
+fi
+
+if ! grep -Eq "^## \[${version}\]" CHANGELOG.md; then
+  echo "verify_changelog_section: CHANGELOG.md has no '## [${version}]' section." >&2
+  echo "Add an entry under '## [${version}] — YYYY-MM-DD' before tagging." >&2
+  exit 1
+fi
+
+unreleased_body="$(awk '
+  /^## \[Unreleased\]/ { inside=1; next }
+  /^## \[/            { inside=0 }
+  inside && NF        { print }
+' CHANGELOG.md | grep -Ev '^[[:space:]]*_Nothing yet' || true)"
+if [ -n "$unreleased_body" ]; then
+  echo "verify_changelog_section: [Unreleased] section is not empty." >&2
+  echo "Move its contents under the version section before tagging." >&2
+  exit 1
+fi
+
+if [ -n "${GITHUB_REF_NAME:-}" ]; then
+  expected_tag="v${version}"
+  if [ "${GITHUB_REF_NAME}" != "$expected_tag" ]; then
+    echo "verify_changelog_section: GITHUB_REF_NAME='${GITHUB_REF_NAME}' does not match moon.mod.json version '${expected_tag}'." >&2
+    echo "Either bump moon.mod.json or retag with '${expected_tag}'." >&2
+    exit 1
+  fi
+fi
+
+echo "verify_changelog_section: CHANGELOG.md has '## [${version}]' and [Unreleased] is empty."


### PR DESCRIPTION
## Summary

- Adds `scripts/verify_changelog_section.sh` and runs it as the first step of the release workflow's `package` job, before any moonbit setup, dry run, or vsce package.
- The script fails the release if `moon.mod.json` version is unreadable, `CHANGELOG.md` has no `## [x.y.z]` section for that version, `[Unreleased]` is non-empty, or `GITHUB_REF_NAME` does not match `v$VERSION` (tag-vs-version drift).
- CONTRIBUTING.md "Releasing" section documents the gate and how to run it locally.

Closes #122.

## Test plan

- [x] Script passes against the current state (0.2.0 present, [Unreleased] empty).
- [x] Script fails (exit 1) with a clear message when the section is missing.
- [x] Script fails when [Unreleased] is populated.
- [x] Script fails when `GITHUB_REF_NAME` does not match the version.
- [ ] CI runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)