### PR TITLE
docs(examples): add v-unsafe-html sanitize-first demo (#125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,9 @@ user-controlled values:
 
   Recommended pattern: sanitize at the call site with an established HTML
   sanitizer before binding the result to `v-unsafe-html`. Never pass raw
-  user input to it.
+  user input to it. See
+  [`examples/unsafe_html.mbtv`](./examples/unsafe_html.mbtv) for a
+  working `sanitize() → v-unsafe-html` demo.
 
 ### Reporting issues
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,7 @@ moon run src/cmd/vapor_moon -- compile examples/basic.mbtv
 | `props_defaults.mbtv` | `defineProps({ ... })` with record-literal defaults. |
 | `provide_inject.mbtv` | Phase 1 `provide` / `inject` registry from `runtime/context` ([#14](https://github.com/ubugeeei/vapor-moon/issues/14)). |
 | `todo_list.mbtv` | End-to-end demo: input + checkbox + filter buttons + remove, all backed by a single signal store. Good entry point for a tour of the full feature set. |
+| `unsafe_html.mbtv` | Sanitize-first pattern for `v-unsafe-html`. The escape hatch is bound only to the output of a sanitizer; raw user input is shown next to it through the default-escaped `{{ … }}` form. See the "Security Model" section of the top-level README for the contract. |
 
 ## Adding an example
 

--- a/examples/unsafe_html.mbtv
+++ b/examples/unsafe_html.mbtv
@@ -1,0 +1,87 @@
+<script>
+import {
+  "mizchi/luna/js/resource" @reactivity,
+  let signal = @reactivity.signal,
+}
+
+// `v-unsafe-html` bypasses the runtime escape pipeline. Vapor Moon will
+// not sanitize the value for you, so the contract here is: every binding
+// site MUST pass through a real sanitizer first. The directive is named
+// `v-unsafe-html` to make that contract obvious at the binding site.
+//
+// In production code, replace `sanitize` with an established sanitizer
+// (e.g. DOMPurify on the client, ammonia / sanitize-html on the server).
+// The stub below allows only `<b>`, `<i>`, `<em>`, `<strong>`, and
+// `<code>` tags so the example stays runnable without an extra dep.
+fn sanitize(input : String) -> String {
+  let allowed = [
+    "<b>", "</b>", "<i>", "</i>", "<em>", "</em>", "<strong>", "</strong>",
+    "<code>", "</code>",
+  ]
+  let mut output = input
+  let mut i = 0
+  while i < output.length() {
+    if output[i].to_int() != '<'.to_int() {
+      i = i + 1
+      continue
+    }
+    let mut end = i + 1
+    while end < output.length() && output[end].to_int() != '>'.to_int() {
+      end = end + 1
+    }
+    if end >= output.length() {
+      // Unclosed angle bracket: drop it and bail.
+      output = output.substring(start=0, end=i) + "&lt;" + output.substring(start=i + 1)
+      i = i + 4
+      continue
+    }
+    let tag = output.substring(start=i, end=end + 1).to_lower()
+    let mut keep = false
+    for candidate in allowed {
+      if tag == candidate {
+        keep = true
+        break
+      }
+    }
+    if keep {
+      i = end + 1
+    } else {
+      let escaped = "&lt;" + output.substring(start=i + 1, end=end + 1)
+      output = output.substring(start=0, end=i) + escaped + output.substring(start=end + 1)
+      i = i + escaped.length()
+    }
+  }
+  output
+}
+
+let raw = signal("Hello <b>world</b>! <script>alert('xss')</script>")
+let safe = signal(sanitize(raw.get()))
+</script>
+
+<template>
+  <article class="unsafe-html-demo">
+    <p>{{ "Raw input (escaped by default through {{ ... }}): " }}</p>
+    <pre>{{ raw.get() }}</pre>
+    <p>{{ "Sanitized + bound via v-unsafe-html:" }}</p>
+    <div class="rendered" v-unsafe-html='safe.get()'></div>
+  </article>
+</template>
+
+<style>
+.unsafe-html-demo {
+  font-family: system-ui, sans-serif;
+}
+
+.unsafe-html-demo pre {
+  background: #f5f5f5;
+  padding: 0.5rem;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+.unsafe-html-demo .rendered {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  border-radius: 4px;
+}
+</style>

--- a/src/compiler/coverage/coverage2_test.mbt
+++ b/src/compiler/coverage/coverage2_test.mbt
@@ -398,3 +398,25 @@ test "select multiple v-model compiles to bind_select_multiple_model" {
   assert_true(output.contains("__selectMultipleModel"))
   assert_true(output.contains("@dom.bind_select_multiple_model"))
 }
+
+///|
+/// Coverage for examples/unsafe_html.mbtv: a `sanitize()` helper feeds
+/// the only `v-unsafe-html` binding in the SFC. Asserts the lowered
+/// output still routes through `raw_html` so the sanitize-first example
+/// stays representative of the runtime contract.
+test "sanitize-first v-unsafe-html example compiles to raw_html" {
+  let source =
+    #|<script>
+    #|fn sanitize(input : String) -> String {
+    #|  input
+    #|}
+    #|let raw : String = "<b>hi</b>"
+    #|let safe : String = sanitize(raw)
+    #|</script>
+    #|<template>
+    #|  <div v-unsafe-html='safe'></div>
+    #|</template>
+  let output = compile_snapshot(source, "UnsafeHtmlSanitizeFirst.mbtv")
+  assert_true(output.contains("raw_html"))
+  assert_true(output.contains("safe"))
+}


### PR DESCRIPTION
## Summary

Closes part of #88 — adds `examples/unsafe_html.mbtv` showing a `sanitize() → v-unsafe-html` pattern, plus a coverage test pinning the lowered output to the runtime `raw_html` helper.

- `examples/unsafe_html.mbtv`: new SFC with an inline tag-allowlist sanitizer (deliberately minimal so the demo compiles without an extra dep; comments point users at DOMPurify / ammonia for production).
- `examples/README.md`: index row added.
- `README.md`: "Security Model" section now links to the example.
- `src/compiler/coverage/coverage2_test.mbt`: snapshot pins `raw_html` as the lowering target so regressions surface here.

Closes #125.

## Test plan

- [x] `moon run src/cmd/vapor_moon -- compile examples/unsafe_html.mbtv` succeeds.
- [x] `moon test --target native src/compiler/coverage` — 134 passed, 0 failed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)