### PR TITLE
ci: pin macOS MoonBit toolchain SHA-256 (closes #126)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,12 @@ permissions:
 env:
   MOONBIT_VERSION: latest
   MOONBIT_EXPECTED_VERSION: "0.1.20260512"
-  # SHA-256 is pinned per host: keep the ubuntu (linux-x86_64) sums here and
-  # let the macOS leg derive its own (currently unpinned — see #83).
+  # SHA-256 is pinned per host. These top-level values are the Linux
+  # (linux-x86_64) sums used by the non-matrix jobs (check-js, e2e,
+  # release). The matrix `check-native-matrix` job below overrides them
+  # per-OS so macOS gets its own pin too. To bump these on a future
+  # toolchain version, re-run CI once with empty values and read the
+  # SHA-256 the setup-moonbit action prints as a workflow notice.
   MOONBIT_ARCHIVE_SHA256: "2c3a5af2020c9ceb3fe11e6457e647a215846d97d71c8e784b3d0a7c8cfc606b"
   MOONBIT_CORE_SHA256: "c68ba56201bd8d99db442b6df599c2c217b0528edec7d6de6e871b6e589c502e"
   NODE_VERSION: "24"
@@ -40,11 +44,13 @@ jobs:
           - os: ubuntu-latest
             archive-sha256: "2c3a5af2020c9ceb3fe11e6457e647a215846d97d71c8e784b3d0a7c8cfc606b"
             core-sha256: "c68ba56201bd8d99db442b6df599c2c217b0528edec7d6de6e871b6e589c502e"
-          # macOS leg has no pinned checksums yet — see #83 for the
-          # SHA-256 pinning follow-up.
           - os: macos-latest
-            archive-sha256: ""
-            core-sha256: ""
+            # macOS uses a different platform archive but the same
+            # bundled core. Both are sourced from the workflow notices
+            # printed by the setup-moonbit action — see CONTRIBUTING.md
+            # "Pinning a new CI platform" for the rotation procedure.
+            archive-sha256: "e4eb64a5eb8270e8bc62825554438c325566e641c7089e2f3bf564e9184331b9"
+            core-sha256: "c68ba56201bd8d99db442b6df599c2c217b0528edec7d6de6e871b6e589c502e"
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,23 @@ When opening a PR, make sure:
 - For non-trivial feature work, open an issue first to align on shape
   before sending the PR.
 
+## Pinning a new CI platform
+
+`.github/workflows/ci.yaml` pins the SHA-256 of the MoonBit toolchain
+archive per matrix leg. When adding a new platform (e.g. `windows-latest`,
+`macos-14`, or `linux-aarch64`):
+
+1. Add the new entry to the `check-native-matrix` `strategy.matrix.include`
+   list with empty `archive-sha256` / `core-sha256` values.
+2. Push the branch — the `setup-moonbit` composite action surfaces the
+   real SHA-256 of `moonbit.tar.gz` and `core.tar.gz` as workflow
+   notices (look for the `tar.gz=…` annotations on the new job).
+3. Copy those values back into the matrix entry. Keep the inline comment
+   pointing here.
+4. Bumping the toolchain version (`MOONBIT_EXPECTED_VERSION`) is the
+   same flow: temporarily blank the per-platform SHA values, push,
+   read the notices, refill.
+
 ## Releasing
 
 1. Bump `version` in all of these so they stay in sync:


### PR DESCRIPTION
## Summary

- Pins the macOS leg of `check-native-matrix` to real SHA-256 sums sourced from recent workflow notices.
- `moonbit.tar.gz` (darwin-aarch64): `e4eb64…84331b9`
- `core.tar.gz`: `c68ba5…589c502e` (identical to Linux — bundled stdlib, not a per-target binary)
- CONTRIBUTING.md gains a "Pinning a new CI platform" section so future Windows / aarch64 additions follow the same blank-pin → push → read notice → fill flow.

Closes #126.

## Test plan

- [ ] CI macOS leg passes with the new pin.
- [ ] Set archive-sha256 to a deliberately wrong value in a follow-up draft to verify the mismatch fails the build (optional safety check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)