### PR TITLE
feat(cli): add `check` subcommand for CI / pre-commit (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ backwards compatible.
 
 ## [Unreleased]
 
-_Nothing yet — the next change starts here._
+### Added
+- `vapor-moon check <file> [more...]` subcommand — pass/fail gate for
+  CI and pre-commit hooks. Silent on success, exits 1 with
+  `path:line:col [severity] message` lines per diagnostic otherwise.
+  Accepts multiple files. Covered by `scripts/smoke_cli.sh` (#135).
 
 ## [0.2.0] — 2026-05-19
 

--- a/scripts/smoke_cli.sh
+++ b/scripts/smoke_cli.sh
@@ -57,3 +57,39 @@ for flag in --version -V; do
   moon run src/cmd/vapor_moon -- "$flag" >"$OUT"
   grep -q "^vapor-moon ${expected_version}$" "$OUT"
 done
+
+# `check` is the pass/fail gate for CI / pre-commit. Silent + exit 0 on
+# success across one or many files; exit 1 with `file:line:col` lines
+# when any file has diagnostics.
+moon run src/cmd/vapor_moon -- check "$ROOT/examples/basic.mbtv" >"$OUT"
+if [ -s "$OUT" ]; then
+  echo "expected `check` to be silent on success"
+  cat "$OUT"
+  exit 1
+fi
+
+moon run src/cmd/vapor_moon -- check "$ROOT/examples/basic.mbtv" "$ROOT/examples/todo_list.mbtv" >"$OUT"
+if [ -s "$OUT" ]; then
+  echo "expected `check` to be silent on multi-file success"
+  cat "$OUT"
+  exit 1
+fi
+
+# Failure path: forge a broken SFC, ensure `check` exits 1 and emits a
+# `path:line:col [severity] message` line.
+broken="$(mktemp "${TMPDIR:-/tmp}/vapor-moon-broken.XXXXXX.mbtv")"
+trap 'rm -f "$OUT" "$broken"' EXIT
+cat > "$broken" <<'EOF'
+<script>
+let emit = defineEmits()
+</script>
+<template>
+  <input v-model:value='broken' />
+</template>
+EOF
+if moon run src/cmd/vapor_moon -- check "$broken" >"$OUT" 2>&1; then
+  echo "expected `check` to fail on a broken SFC"
+  cat "$OUT"
+  exit 1
+fi
+grep -qE ":[0-9]+:[0-9]+ \[error\] " "$OUT"

--- a/src/cmd/vapor_moon_cli/cli.mbt
+++ b/src/cmd/vapor_moon_cli/cli.mbt
@@ -63,6 +63,41 @@ pub fn run(args : Array[String]) -> Unit {
       let source = read_text_or_exit(path)
       println(@tooling.diagnostics(source, filename=path).to_string())
     }
+    "check" => {
+      // Pass/fail gate for CI and pre-commit hooks: silent on success,
+      // exit 1 with one diagnostic line per file otherwise. Accepts one
+      // or more file paths (everything from args[2] onward).
+      let paths = args[2:]
+      let mut had_error = false
+      for p in paths {
+        let source = read_text_or_exit(p)
+        let diagnostics = @tooling.diagnostics(source, filename=p)
+        if diagnostics.length() > 0 {
+          had_error = true
+          for d in diagnostics {
+            // `file:line:col [severity] message` — line/character in
+            // ToolingDiagnostic are zero-based (LSP), shift to one-based
+            // for human / editor parity.
+            let line = d.location.range.start.line + 1
+            let col = d.location.range.start.character + 1
+            println(
+              p +
+              ":" +
+              line.to_string() +
+              ":" +
+              col.to_string() +
+              " [" +
+              d.severity +
+              "] " +
+              d.message,
+            )
+          }
+        }
+      }
+      if had_error {
+        @sys.exit(1)
+      }
+    }
     "hover" =>
       if args.length() < 5 {
         exit_usage()
@@ -591,6 +626,9 @@ fn print_help() -> Unit {
   )
   println(
     "  diagnostics <file.mbtv>                            Print diagnostics for one file.",
+  )
+  println(
+    "  check       <file.mbtv> [more.mbtv...]             Validate one or more files; exit 0 silently on success, exit 1 with `file:line:col [severity] message` lines otherwise.",
   )
   println(
     "  hover       <file.mbtv> <line> <character>         Print the hover result at a position.",


### PR DESCRIPTION
## Summary

- `vapor-moon check <file.mbtv> [more...]` — silent + exit 0 on success, exit 1 with one `path:line:col [severity] message` line per diagnostic otherwise.
- Accepts multiple files so pre-commit hooks can run it on a glob.
- `scripts/smoke_cli.sh` covers single-file success, multi-file success, and the failure path.
- CHANGELOG `[Unreleased]` records the addition.

Closes #135.

## Test plan

- [x] Local: `moon run src/cmd/vapor_moon -- check examples/basic.mbtv` exits 0 silently.
- [x] Local: same on two files (basic + todo_list) exits 0 silently.
- [x] Local: broken SFC exits 1 with the formatted diagnostic line.
- [x] `bash scripts/smoke_cli.sh` passes.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)