### PR TITLE
feat(cli): add `new` subcommand for SFC scaffolding (closes #127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ backwards compatible.
   CI and pre-commit hooks. Silent on success, exits 1 with
   `path:line:col [severity] message` lines per diagnostic otherwise.
   Accepts multiple files. Covered by `scripts/smoke_cli.sh` (#135).
+- `vapor-moon new <Name> [--force]` subcommand — scaffolds
+  `./<Name>.mbtv` from a minimal starter (script + reactive signal +
+  scoped style). Refuses to overwrite an existing file unless
+  `--force` is passed. Covered by `scripts/smoke_cli.sh` (#127).
 
 ## [0.2.0] — 2026-05-19
 

--- a/scripts/smoke_cli.sh
+++ b/scripts/smoke_cli.sh
@@ -75,6 +75,31 @@ if [ -s "$OUT" ]; then
   exit 1
 fi
 
+# `new` scaffolds a starter SFC. Validates: success message, generated
+# file compiles, refuses to overwrite without --force, --force allows
+# overwrite.
+NEW_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vapor-moon-new.XXXXXX")"
+(
+  cd "$NEW_DIR"
+  moon run "$ROOT/src/cmd/vapor_moon" -- new Counter >"$OUT"
+  grep -q "^created Counter.mbtv$" "$OUT"
+  if [ ! -f Counter.mbtv ]; then
+    echo "expected vapor-moon new to create Counter.mbtv"
+    exit 1
+  fi
+  moon run "$ROOT/src/cmd/vapor_moon" -- compile Counter.mbtv >"$OUT"
+  grep -q "component=Counter" "$OUT"
+  if moon run "$ROOT/src/cmd/vapor_moon" -- new Counter >"$OUT" 2>&1; then
+    echo "expected vapor-moon new to refuse overwriting"
+    cat "$OUT"
+    exit 1
+  fi
+  grep -q "already exists" "$OUT"
+  moon run "$ROOT/src/cmd/vapor_moon" -- new Counter --force >"$OUT"
+  grep -q "^created Counter.mbtv$" "$OUT"
+)
+rm -rf "$NEW_DIR"
+
 # Failure path: forge a broken SFC, ensure `check` exits 1 and emits a
 # `path:line:col [severity] message` line.
 broken="$(mktemp "${TMPDIR:-/tmp}/vapor-moon-broken.XXXXXX.mbtv")"

--- a/src/cmd/vapor_moon_cli/cli.mbt
+++ b/src/cmd/vapor_moon_cli/cli.mbt
@@ -35,6 +35,12 @@ pub fn run(args : Array[String]) -> Unit {
     run_doctor()
     return
   }
+  // `new` takes a component name and optional `--force` flag; route it
+  // before the generic < 3 args check so the usage message is correct.
+  if args[1] == "new" {
+    run_new(args[2:])
+    return
+  }
   if args.length() < 3 {
     exit_usage()
     return
@@ -648,6 +654,9 @@ fn print_help() -> Unit {
   println(
     "  doctor                                             Print environment diagnostics (MOON_HOME, moon.mod.json detection, etc.).",
   )
+  println(
+    "  new         <Name> [--force]                       Scaffold ./<Name>.mbtv from a minimal starter template; refuses to overwrite unless --force is set.",
+  )
   println("")
   println("Positions are zero-based (LSP semantics).")
 }
@@ -664,6 +673,106 @@ fn print_help() -> Unit {
 /// - Presence of the `vapor_moon` package in that manifest.
 ///
 /// Intentionally does not shell out to `moon version` — keeping doctor
+/// Scaffold `./<Name>.mbtv` from a minimal starter template. Refuses to
+/// overwrite an existing file unless `--force` is passed so a stray
+/// `vapor-moon new Counter` doesn't clobber a real component.
+///
+/// `name` becomes the file stem; bare component names map to
+/// `./<Name>.mbtv`. A name with a `/` is treated as a path: the leading
+/// directories are taken as-is, the final segment becomes the stem.
+fn run_new(extra : ArrayView[String]) -> Unit {
+  if extra.length() < 1 {
+    println(
+      "Usage: vapor-moon new <Name> [--force]",
+    )
+    @sys.exit(2)
+    return
+  }
+  let name = extra[0]
+  let mut force = false
+  let mut index = 1
+  while index < extra.length() {
+    match extra[index] {
+      "--force" | "-f" => force = true
+      other => {
+        println("vapor-moon new: unknown flag `" + other + "`")
+        @sys.exit(2)
+        return
+      }
+    }
+    index += 1
+  }
+  if name.is_empty() {
+    println("vapor-moon new: <Name> cannot be empty")
+    @sys.exit(2)
+    return
+  }
+  // Strip a trailing `.mbtv` if the user typed one — the subcommand
+  // appends the extension itself so authors can write either spelling.
+  let stem = if name.has_suffix(".mbtv") {
+    name.substring(start=0, end=name.length() - 5).to_string()
+  } else {
+    name
+  }
+  let target = stem + ".mbtv"
+  if @fs.path_exists(target) && !force {
+    println(
+      "vapor-moon new: " + target + " already exists. Pass --force to overwrite.",
+    )
+    @sys.exit(1)
+    return
+  }
+  @fs.write_string_to_file(target, starter_template(stem), encoding="utf8") catch {
+    err => {
+      println("vapor-moon new: failed to write " + target + ": " + err.to_string())
+      @sys.exit(1)
+      return
+    }
+  }
+  println("created " + target)
+}
+
+///|
+/// Starter SFC body for `vapor-moon new`. Kept small enough to feel
+/// like a stub but complete enough to compile and round-trip through
+/// every stage of the pipeline (script + template + scoped style).
+fn starter_template(name : String) -> String {
+  // The unscoped class name uses the component stem so the rendered
+  // markup is easy to recognize in dev tools without a manual rename.
+  let css_class = "vapor-moon-" + name.to_lower()
+  "<script>\n" +
+  "import {\n" +
+  "  \"mizchi/luna/js/resource\" @reactivity,\n" +
+  "  let signal = @reactivity.signal,\n" +
+  "}\n" +
+  "\n" +
+  "let count = signal(0)\n" +
+  "</script>\n" +
+  "\n" +
+  "<template>\n" +
+  "  <button class=\"" +
+  css_class +
+  "\" @click='count.update(fn(n) { n + 1 })'>\n" +
+  "    {{ \"" +
+  name +
+  ": \" + count.get().to_string() }}\n" +
+  "  </button>\n" +
+  "</template>\n" +
+  "\n" +
+  "<style>\n" +
+  "." +
+  css_class +
+  " {\n" +
+  "  padding: 0.5rem 1rem;\n" +
+  "  border-radius: 4px;\n" +
+  "  border: 1px solid #ccc;\n" +
+  "  background: #f5f5f5;\n" +
+  "  cursor: pointer;\n" +
+  "}\n" +
+  "</style>\n"
+}
+
+///|
 /// dependency-free means it works in environments where moon is not on
 /// PATH (which is itself a useful diagnostic).
 fn run_doctor() -> Unit {

--- a/src/cmd/vapor_moon_cli/cli.mbt
+++ b/src/cmd/vapor_moon_cli/cli.mbt
@@ -682,9 +682,7 @@ fn print_help() -> Unit {
 /// directories are taken as-is, the final segment becomes the stem.
 fn run_new(extra : ArrayView[String]) -> Unit {
   if extra.length() < 1 {
-    println(
-      "Usage: vapor-moon new <Name> [--force]",
-    )
+    println("Usage: vapor-moon new <Name> [--force]")
     @sys.exit(2)
     return
   }
@@ -717,14 +715,18 @@ fn run_new(extra : ArrayView[String]) -> Unit {
   let target = stem + ".mbtv"
   if @fs.path_exists(target) && !force {
     println(
-      "vapor-moon new: " + target + " already exists. Pass --force to overwrite.",
+      "vapor-moon new: " +
+      target +
+      " already exists. Pass --force to overwrite.",
     )
     @sys.exit(1)
     return
   }
   @fs.write_string_to_file(target, starter_template(stem), encoding="utf8") catch {
     err => {
-      println("vapor-moon new: failed to write " + target + ": " + err.to_string())
+      println(
+        "vapor-moon new: failed to write " + target + ": " + err.to_string(),
+      )
       @sys.exit(1)
       return
     }


### PR DESCRIPTION
## Summary

- `vapor-moon new <Name> [--force]` writes a starter `./<Name>.mbtv` with a reactive signal + scoped style.
- Refuses to overwrite an existing file unless `--force` / `-f` is passed.
- `.mbtv` suffix is stripped if the user types it.
- `print_help` lists the new subcommand.
- `CHANGELOG.md` `[Unreleased]` records the addition.
- `scripts/smoke_cli.sh` covers success, refusal, and `--force` override.

Closes #127.

## Test plan

- [x] Local: `vapor-moon new Counter` creates a compiling Counter.mbtv (verified via `vapor-moon compile`).
- [x] Local: second invocation without `--force` exits 1 with `already exists` message.
- [x] Local: `--force` overwrites.
- [x] `bash scripts/smoke_cli.sh` passes end-to-end.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)