### PR TITLE
style: run moon fmt + add ci drift guard (closes #142)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,18 @@ jobs:
           core-sha256: ${{ matrix.core-sha256 }}
       - name: Moon check
         run: moon check --deny-warn --warn-list -deprecated_syntax-deprecated --target native 2> >(grep -v 'WARN Duplicate alias' >&2)
+      - name: Moon fmt drift guard
+        # Run once on the ubuntu leg only — moon fmt is deterministic
+        # across platforms, so the second OS would just duplicate the
+        # check. Fails if any tracked .mbt file would change.
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          moon fmt
+          if ! git diff --quiet; then
+            echo "::error::moon fmt produced changes. Run \`moon fmt\` locally and commit the result."
+            git --no-pager diff --stat
+            exit 1
+          fi
       - name: Moon native tests
         run: moon test --target native
       - name: CLI smoke test

--- a/src/cmd/vapor_moon_cli/cli.mbt
+++ b/src/cmd/vapor_moon_cli/cli.mbt
@@ -636,16 +636,15 @@ fn run_doctor() -> Unit {
   println("expected MoonBit   : 0.1.20260512")
   match @env.get_env_var("MOON_HOME") {
     Some(home) => println("MOON_HOME          : " + home)
-    None => println("MOON_HOME          : <unset> (will fall back to $HOME/.moon)")
+    None =>
+      println("MOON_HOME          : <unset> (will fall back to $HOME/.moon)")
   }
   match find_moon_mod_json(".") {
     Some(path) => {
       println("moon.mod.json      : " + path)
       let content = @fs.read_file_to_string(path, encoding="utf8") catch {
         err => {
-          println(
-            "  ! failed to read moon.mod.json: " + err.to_string(),
-          )
+          println("  ! failed to read moon.mod.json: " + err.to_string())
           failures = failures + 1
           ""
         }
@@ -658,7 +657,9 @@ fn run_doctor() -> Unit {
       }
     }
     None => {
-      println("moon.mod.json      : <not found> (run `vapor-moon doctor` inside a moon workspace)")
+      println(
+        "moon.mod.json      : <not found> (run `vapor-moon doctor` inside a moon workspace)",
+      )
       failures = failures + 1
     }
   }


### PR DESCRIPTION
## Summary

- Runs `moon fmt` over `src/cmd/vapor_moon_cli/cli.mbt`, picking up three lines of drift introduced by #110 (doctor subcommand).
- Adds a `Moon fmt drift guard` step on the ubuntu leg of `check-native-matrix`: runs `moon fmt`, fails if `git diff` is non-empty. The pre-commit hook remains the local guardrail; CI is now the system of record.

Closes #142.

## Test plan

- [x] Locally: `moon fmt` produces a clean tree after this commit.
- [ ] CI green; in particular the new "Moon fmt drift guard" step.
- [ ] Deliberately introduce a mis-formatted change in a follow-up draft and verify the guard fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)