### PR TITLE
fix(scripts): use CDPATH='' to silence shellcheck SC1007 (unblocks #113)

### DIFF
--- a/scripts/patch_mooncakes.sh
+++ b/scripts/patch_mooncakes.sh
@@ -4,7 +4,7 @@ set -eu
 export LC_ALL=C
 export LANG=C
 
-ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 PKG="$ROOT/.mooncakes/moonbitlang/yacc/src/lib/parser/test/moon.pkg"
 TEST_FILE="$ROOT/.mooncakes/moonbitlang/yacc/src/lib/parser/test/test.mbt"
 PARSER_REPORT="$ROOT/.mooncakes/moonbitlang/parser/basic/report.mbt"

--- a/scripts/smoke_cli.sh
+++ b/scripts/smoke_cli.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 OUT="$(mktemp "${TMPDIR:-/tmp}/vapor-moon-cli.XXXXXX")"
 trap 'rm -f "$OUT"' EXIT
 

--- a/scripts/smoke_lsp.sh
+++ b/scripts/smoke_lsp.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 
 python3 - "$ROOT" <<'PY'
 import json

--- a/scripts/verify_changelog_section.sh
+++ b/scripts/verify_changelog_section.sh
@@ -16,7 +16,7 @@
 # Run locally via `bash scripts/verify_changelog_section.sh`.
 set -euo pipefail
 
-ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 cd "$ROOT"
 
 version="$(grep -m1 '"version"' moon.mod.json | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"

--- a/scripts/verify_publish_dry_run.sh
+++ b/scripts/verify_publish_dry_run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 OUT="$(mktemp "${TMPDIR:-/tmp}/vapor-moon-publish.XXXXXX")"
 trap 'rm -f "$OUT"' EXIT
 


### PR DESCRIPTION
## Summary

The Nix flake check (PR #113) enforces shellcheck-clean shell scripts and was failing with SC1007 on the `CDPATH= cd ...` pattern in five scripts. Shellcheck reads it as a typo for `CDPATH = cd`; switching to the exact form its hint recommends (`CDPATH=''`) silences the warning without changing runtime behavior.

Same semantics, no warning. Unblocks #113 (and indirectly #117).

## Test plan

- [x] Local `bash scripts/smoke_cli.sh` passes.
- [ ] CI green.
- [ ] After this merges, rebase #113 — nix flake check should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)